### PR TITLE
Fix issue #6

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -93,7 +93,7 @@ class MoneyField(models.DecimalField):
         if hasattr(cls, '_default_manager'):
             cls._default_manager = money_manager(cls._default_manager)
         elif hasattr(cls, 'objects'):
-            cls.objects = money_manager(cls._default_manager)
+            cls.objects = money_manager(cls.objects)
         else:
             cls.objects = money_manager(models.Manager)
         


### PR DESCRIPTION
We check whether the class has the objects attribute but then still access _default_manager. Obvious fix for issue #6. I hit this also when I only have one MoneyField using Django 1.4 by the way.
