### PR TITLE
Fix AttributeError when Model inherit a mager

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -90,7 +90,7 @@ class MoneyField(models.DecimalField):
         
         from managers import money_manager
 
-        if hasattr(cls, '_default_manager'):
+        if getattr(cls, '_default_manager', None):
             cls._default_manager = money_manager(cls._default_manager)
         elif hasattr(cls, 'objects'):
             cls.objects = money_manager(cls.objects)


### PR DESCRIPTION
AttributeError: 'NoneType' object has no attribute 'get_query_set'
When a Model inherit from an Abstract one which implement a Manager.
In this case '_default_manager' is defined but equal to None
