### PR TITLE
Fix South problem

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -68,6 +68,7 @@ class MoneyField(models.DecimalField):
             raise Exception("You have to provide a decimal_places attribute to Money fields.")
         
         self.default_currency = default_currency
+        self.frozen_by_south = kwargs.pop('frozen_by_south', None)
         super(MoneyField, self).__init__(verbose_name, name, max_digits, decimal_places, default=default, **kwargs)
     
     def to_python(self, value):


### PR DESCRIPTION
Hi, I was getting this, and the fix here made it go away and on top of that I completed a successful south migration.

```
./manage.py schemamigration deltag --auto && ./manage.py migrate deltag
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 443, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/base.py", line 196, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python2.7/dist-packages/south/management/commands/schemamigration.py", line 100, in handle
    old_orm = last_migration.orm(),
  File "/usr/local/lib/python2.7/dist-packages/south/utils/__init__.py", line 62, in method
    value = function(self)
  File "/usr/local/lib/python2.7/dist-packages/south/migration/base.py", line 431, in orm
    return FakeORM(self.migration_class(), self.app_label())
  File "/usr/local/lib/python2.7/dist-packages/south/orm.py", line 45, in FakeORM
    _orm_cache[args] = _FakeORM(*args)  
  File "/usr/local/lib/python2.7/dist-packages/south/orm.py", line 124, in __init__
    self.models[name] = self.make_model(app_label, model_name, data)
  File "/usr/local/lib/python2.7/dist-packages/south/orm.py", line 317, in make_model
    field = self.eval_in_context(code, app, extra_imports)
  File "/usr/local/lib/python2.7/dist-packages/south/orm.py", line 235, in eval_in_context
    return eval(code, globals(), fake_locals)
  File "<string>", line 1, in <module>
  File "/.../djmoney/models/fields.py", line 71, in __init__
    super(MoneyField, self).__init__(verbose_name, name, max_digits, decimal_places, default=default, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/fields/__init__.py", line 838, in __init__
    Field.__init__(self, verbose_name, name, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'frozen_by_south'
```
