### PR TITLE
LOOKUP_SEP moved in 1.5

### DIFF
--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -7,7 +7,9 @@ def _expand_money_params(kwargs):
     try :
       from django.db.models.sql.constants import LOOKUP_SEP, QUERY_TERMS
     except ImportError:
+      # 1.5 fix
       from django.db.models.constants import LOOKUP_SEP
+      from django.db.models.sql.constants import QUERY_TERMS
     to_append = {}
     for name, value in kwargs.items():
         if isinstance(value, Money):


### PR DESCRIPTION
This patch handles the movement of LOOKUP_SEP to from django.db.models.constants in Django 1.5.
