### PR TITLE
valid django 1.3+ settings

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,12 +1,24 @@
+import warnings
 
-DATABASE_ENGINE   = 'sqlite3'  
-DATABASE_NAME     = ':memory:'   
-DATABASE_USER     = ''           
-DATABASE_PASSWORD = ''       
-DATABASE_HOST     = ''           
-DATABASE_PORT     = ''
+warnings.simplefilter('ignore', Warning)
 
-INSTALLED_APPS = (
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+    }
+}
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.sites',
     'djmoney',
-    'testapp'
-)
+    'testapp',
+]
+
+SITE_ID = 1
+ROOT_URLCONF = 'core.urls'
+
+SECRET_KEY = 'foobar'


### PR DESCRIPTION
The settings file needs to meet the requirements be able to run tests in django 1.3+
