### PR TITLE
Deserializer broke fixtures loading before unittesting

### DIFF
--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -1,45 +1,44 @@
+# coding=utf-8
+
 import json
-from StringIO import StringIO
 from decimal import Decimal
-from django.core.serializers.json import Deserializer as JSONDeserializer
+
+from django.core.serializers.python import Deserializer as PythonDeserializer
 from django.core.serializers.json import Serializer as JSONSerializer
 from django.core.serializers.python import _get_model
-from django.core.serializers.base import DeserializationError
+from django.utils import six
+
 from djmoney.models.fields import MoneyField
 
-### This works with reversion but may break with loaddata and dumpdata
-### Needs more work!
-### /benjaoming 2013-07-30
-
 Serializer = JSONSerializer
+
 
 def Deserializer(stream_or_string, **options):
     """
     Deserialize a stream or string of JSON data.
     """
-    if isinstance(stream_or_string, basestring):
-        stream = StringIO(stream_or_string)
-    else:
-        stream = stream_or_string
+    if not isinstance(stream_or_string, (bytes, six.string_types)):
+        stream_or_string = stream_or_string.read()
+    if isinstance(stream_or_string, bytes):
+        stream_or_string = stream_or_string.decode('utf-8')
     try:
         obj_list = []
-        for obj in json.load(stream):
+        for obj in json.loads(stream_or_string):
             money_fields = {}
+            fields = {}
             Model = _get_model(obj["model"])
-            for (field_name, field_value) in obj["fields"].iteritems():
+            for (field_name, field_value) in obj['fields'].iteritems():
                 field = Model._meta.get_field(field_name)
                 if isinstance(field, MoneyField):
                     money_fields[field_name] = Decimal(
                         field_value.split(" ")[0])
+                else:
+                    fields[field_name] = field_value
+            obj['fields'] = fields
 
-            obj["fields"] = dict(
-                filter(lambda (k, v): k not in money_fields.keys(),
-                       obj["fields"].items()))
-
-            for obj in JSONDeserializer([obj], **options):
+            for obj in PythonDeserializer([obj], **options):
                 for field, value in money_fields.items():
                     setattr(obj.object, field, value)
                 yield obj
-
     except GeneratorExit:
         raise


### PR DESCRIPTION
When doing unittests, fixtures loading was failing because JSONDeserializer tried to call .read() with the `[obj]` list used as parameter. 

`stream_or_string` is already parsed from JSON, so PythonDeserializer can be used instead of JSONDeserializer
