### PR TITLE
support for relative fields in the queryset.

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from django.db import models
 from django.conf import settings
+from django.db.models.sql.expressions import SQLEvaluator
 try:
     from django.utils.encoding import smart_unicode
 except ImportError:
@@ -233,6 +234,8 @@ class MoneyField(models.DecimalField):
                                          **kwargs)
 
     def to_python(self, value):
+        if isinstance(value, SQLEvaluator):
+            return value
         if isinstance(value, Money):
             value = value.amount
         if isinstance(value, tuple):
@@ -268,6 +271,8 @@ class MoneyField(models.DecimalField):
         setattr(cls, self.name, MoneyFieldProxy(self))
 
     def get_db_prep_save(self, value, connection):
+        if isinstance(value, SQLEvaluator):
+            return value
         if isinstance(value, Money):
             value = value.amount
             return value

--- a/djmoney/tests/model_tests.py
+++ b/djmoney/tests/model_tests.py
@@ -8,7 +8,7 @@ from django.db.models import F
 from moneyed import Money
 from .testapp.models import (ModelWithVanillaMoneyField,
     ModelRelatedToModelWithMoney, ModelWithChoicesMoneyField, BaseModel, InheritedModel, InheritorModel,
-    SimpleModel, NullMoneyFieldModel)
+    SimpleModel, NullMoneyFieldModel, ModelWithTwoMoneyFields)
 import moneyed
 
 
@@ -47,6 +47,15 @@ class VanillaMoneyFieldTestCase(TestCase):
         mymodel.save()
         mymodel = ModelWithVanillaMoneyField.objects.get(pk=mymodel.pk)
         self.assertEquals(Money(0, 'USD'), mymodel.money)
+
+    def testComparisonLookup(self):
+        ModelWithTwoMoneyFields.objects.create(amount1=Money(1, 'USD'), amount2=Money(2, 'USD'))
+        ModelWithTwoMoneyFields.objects.create(amount1=Money(2, 'USD'), amount2=Money(0, 'USD'))
+        ModelWithTwoMoneyFields.objects.create(amount1=Money(3, 'USD'), amount2=Money(0, 'USD'))
+        ModelWithTwoMoneyFields.objects.create(amount1=Money(4, 'USD'), amount2=Money(0, 'GHS'))
+
+        qs = ModelWithTwoMoneyFields.objects.filter(amount1__gt=F('amount2'))
+        self.assertEquals(2, qs.count())
 
     def testExactMatch(self):
 

--- a/djmoney/tests/testapp/models.py
+++ b/djmoney/tests/testapp/models.py
@@ -13,6 +13,10 @@ import moneyed
 class ModelWithVanillaMoneyField(models.Model):
     money = MoneyField(max_digits=10, decimal_places=2)
 
+class ModelWithTwoMoneyFields(models.Model):
+    amount1 = MoneyField(max_digits=10, decimal_places=2)
+    amount2 = MoneyField(max_digits=10, decimal_places=3)
+
 
 class ModelRelatedToModelWithMoney(models.Model):
     moneyModel = models.ForeignKey(ModelWithVanillaMoneyField)


### PR DESCRIPTION
It is now possible to execute a query like the following:

MyModel.objects.filter(amount1__gt=F(amount2))

NOTE: this also adds the condition, that the currencies must match.
