### PR TITLE
Support for value of None in MoneyField.compress.

### DIFF
--- a/djmoney/forms/fields.py
+++ b/djmoney/forms/fields.py
@@ -25,4 +25,9 @@ class MoneyField(MultiValueField):
         super(MoneyField, self).__init__(fields, *args, **kwargs)
 
     def compress(self, data_list):
+        try:
+            if data_list[0] is None:
+                return None
+        except IndexError:
+            return None
         return Money(*data_list[:2])


### PR DESCRIPTION
Leaving a MoneyField blank in the Django admin site caused an issue when
attempting to save an exception was raised since Money was getting an
argument list of None.
