### PR TITLE
Added "choices=" to instantiation of currency widget

### DIFF
--- a/djmoney/forms/widgets.py
+++ b/djmoney/forms/widgets.py
@@ -23,7 +23,7 @@ class MoneyWidget(MultiWidget):
         if not amount_widget:
             amount_widget = TextInput
         if not currency_widget:
-            currency_widget = Select(choices)
+            currency_widget = Select(choices=choices)
         widgets = (amount_widget, currency_widget)
         super(MoneyWidget, self).__init__(widgets, *args, **kwargs)
 


### PR DESCRIPTION
This prevents a "list has no attribute copy()" error when using the MoneyWidget directly in a form definition
