### PR TITLE
Fixes #101: Appends _currency to non-money ExpressionFields

### DIFF
--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -2,6 +2,11 @@ from functools import wraps
 
 import django
 from django.db.models.expressions import ExpressionNode, F
+from django.db.models.sql.query import Query
+from djmoney.models.fields import MoneyField
+from django.db.models.query_utils import Q
+from moneyed import Money
+
 
 try:
     from django.utils.encoding import smart_unicode
@@ -11,40 +16,123 @@ except ImportError:
 
 from djmoney.utils import get_currency_field_name
 
+try:
+    from django.db.models.constants import LOOKUP_SEP
+except ImportError:
+    # Django < 1.5
+    LOOKUP_SEP = '__'
 
-def _expand_money_params(kwargs):
-    def get_clean_name(name):
-        # Get rid of __lt, __gt etc for the currency lookup
-        path = name.split(LOOKUP_SEP)
-        if path[-1] in QUERY_TERMS:
-            return LOOKUP_SEP.join(path[:-1])
-        else:
-            return name
+from django.db.models.sql.constants import QUERY_TERMS
 
-    from moneyed import Money
-    try:
-        from django.db.models.constants import LOOKUP_SEP
-    except ImportError:
-        # Django < 1.5
-        LOOKUP_SEP = '__'
-    from django.db.models.sql.constants import QUERY_TERMS
 
+def _get_clean_name(name):
+
+    # Get rid of __lt, __gt etc for the currency lookup
+    path = name.split(LOOKUP_SEP)
+    if path[-1] in QUERY_TERMS:
+        return LOOKUP_SEP.join(path[:-1])
+    else:
+        return name
+
+
+def _get_field(model, name):
+    if django.VERSION[0] >= 1 and django.VERSION[1] >= 8:
+        # Django 1.8+ - can use something like 
+        # expression.output_field.get_internal_field() == 'Money..'
+        raise NotImplementedError("Django 1.8+ support is not implemented.")
+
+    from django.db.models.fields import FieldDoesNotExist
+
+    # Create a fake query object so we can easily work out what field
+    # type we are dealing with
+    qs = Query(model)
+    opts = qs.get_meta()
+    alias = qs.get_initial_alias()
+
+    parts = name.split(LOOKUP_SEP)
+
+    # The following is borrowed from the innards of Query.add_filter - it strips out __gt, __exact et al.
+    num_parts = len(parts)
+    if len(parts) > 1 and parts[-1] in qs.query_terms:
+        # Traverse the lookup query to distinguish related fields from
+        # lookup types.
+        lookup_model = model
+        for counter, field_name in enumerate(parts):
+            try:
+                lookup_field = lookup_model._meta.get_field(field_name)
+            except FieldDoesNotExist:
+                # Not a field. Bail out.
+                parts.pop()
+                break
+            # Unless we're at the end of the list of lookups, let's attempt
+            # to continue traversing relations.
+            if (counter + 1) < num_parts:
+                try:
+                    lookup_model = lookup_field.rel.to
+                except AttributeError:
+                    # Not a related field. Bail out.
+                    parts.pop()
+                    break
+
+    if django.VERSION[0] >= 1 and django.VERSION[1] in (6, 7):
+        # Django 1.6-1.7
+        field = qs.setup_joins(parts, opts, alias)[0]
+    else:
+        # Django 1.4-1.5
+        field = qs.setup_joins(parts, opts, alias, False)[0]
+
+    return field
+
+
+def _expand_money_args(model, args, depth=0):
+    """
+    Augments args so that they contain _currency lookups - ie.. Q() | Q()
+    """
+    for arg in args:
+        for i, child in enumerate(arg.children):
+            if isinstance(child, Q):
+                _expand_money_args(model, [child], depth + 3)
+            elif isinstance(child, (list, tuple)):
+                name, value = child
+                if isinstance(value, Money):
+                    clean_name = _get_clean_name(name)
+                    arg.children[i] = Q(*[
+                        child,
+                        (get_currency_field_name(clean_name), smart_unicode(value.currency))
+                    ])
+                if isinstance(value, ExpressionNode):
+                    field = _get_field(model, name)
+                    if isinstance(field, MoneyField):
+                        clean_name = _get_clean_name(name)
+                        arg.children[i] = Q(*[
+                            child, 
+                            ('_'.join([clean_name, 'currency']), F('_'.join([value.name, 'currency'])))
+                        ])
+    return args
+
+
+def _expand_money_kwargs(model, kwargs):
+    """
+    Augments kwargs so that they contain _currency lookups.
+    """
     to_append = {}
     for name, value in kwargs.items():
         if isinstance(value, Money):
-            clean_name = get_clean_name(name)
+            clean_name = _get_clean_name(name)
             to_append[name] = value.amount
             to_append[get_currency_field_name(clean_name)] = smart_unicode(
                 value.currency)
         if isinstance(value, ExpressionNode):
-            clean_name = get_clean_name(name)
-            to_append['_'.join([clean_name, 'currency'])] = F('_'.join([value.name, 'currency']))
+            field = _get_field(model, name)
+            if isinstance(field, MoneyField):
+                clean_name = _get_clean_name(name)
+                to_append['_'.join([clean_name, 'currency'])] = F('_'.join([value.name, 'currency']))
 
     kwargs.update(to_append)
     return kwargs
 
 
-def understands_money(func):
+def understands_money(model, func):
     """
     Used to wrap a queryset method with logic to expand
     a query from something like:
@@ -58,8 +146,9 @@ def understands_money(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
+        args = _expand_money_args(model, args)
         kwargs = kwargs.copy()
-        kwargs = _expand_money_params(kwargs)
+        kwargs = _expand_money_kwargs(model, kwargs)
         return func(*args, **kwargs)
 
     return wrapper
@@ -71,10 +160,10 @@ RELEVANT_QUERYSET_METHODS = ['dates', 'distinct', 'extra', 'get',
                              'order_by', 'select_related', 'values']
 
 
-def add_money_comprehension_to_queryset(qs):
+def add_money_comprehension_to_queryset(model, qs):
     # Decorate each relevant method with understand_money in the queryset given
     for attr in RELEVANT_QUERYSET_METHODS:
-        setattr(qs, attr, understands_money(getattr(qs, attr)))
+        setattr(qs, attr, understands_money(model, getattr(qs, attr)))
     return qs
 
 
@@ -106,7 +195,7 @@ def money_manager(manager):
             s = super(MoneyManager, self)
             method = getattr(s, 'get_queryset',
                              getattr(s, 'get_query_set', None))
-            return add_money_comprehension_to_queryset(method(*args, **kwargs))
+            return add_money_comprehension_to_queryset(self.model, method(*args, **kwargs))
 
         # If we are being called by code pre Django 1.6, need
         # 'get_query_set'.

--- a/djmoney/tests/__init__.py
+++ b/djmoney/tests/__init__.py
@@ -1,3 +1,4 @@
 from .model_tests import *
 from .form_tests import *
 from .tags_tests import *
+from .managers_tests import *

--- a/djmoney/tests/managers_tests.py
+++ b/djmoney/tests/managers_tests.py
@@ -14,6 +14,12 @@ class ExpandMoneyArgsTestCase(TestCase):
             []
         )
 
+        # Test non-Q arg (such as it receives for an order_by
+        self.assertEqual(
+            _expand_money_args(ModelWithNonMoneyField(), ['money']),
+            ['money']
+        )
+
         # Test
         #   (AND: ('money', 0 USD))
         # results in;

--- a/djmoney/tests/managers_tests.py
+++ b/djmoney/tests/managers_tests.py
@@ -1,0 +1,120 @@
+from django.test import TestCase
+from django.db.models import Q
+from djmoney.models.managers import _expand_money_args
+from djmoney.tests.testapp.models import ModelWithNonMoneyField
+from moneyed import Money
+
+
+class ExpandMoneyArgsTestCase(TestCase):
+
+    def testExpandMoneyArgs(self):
+        # Test no args
+        self.assertEqual(
+            _expand_money_args(ModelWithNonMoneyField(), []),
+            []
+        )
+
+        # Test
+        #   (AND: ('money', 0 USD))
+        # results in;
+        #   (AND: (AND: ('money', 0 USD), ('money_currency', u'USD')))
+        actual = _expand_money_args(ModelWithNonMoneyField(), [Q(money=Money(0, 'USD'))])
+
+        self.assertEqual(len(actual), 1)
+        arg = actual[0]
+
+        self.assertIsInstance(arg, Q)
+        self.assertEqual(arg.connector, Q.AND)
+        self.assertEqual(len(arg.children), 1)
+        self.assertIsInstance(arg.children[0], Q)
+        self.assertEqual(arg.children[0].connector, Q.AND)
+        self.assertIn(('money', Money(0, 'USD')), arg.children[0].children)
+        self.assertIn(('money_currency', 'USD'), arg.children[0].children)
+
+        # Test
+        #   (AND: ('desc', 'foo'), ('money', 0 USD))
+        # results in;
+        #   (AND: ('desc', 'foo'), (AND: ('money', 0 USD), ('money_currency', u'USD')))
+        actual = _expand_money_args(ModelWithNonMoneyField(), [Q(money=Money(0, 'USD'), desc='foo')])
+        self.assertEqual(len(actual), 1)
+
+        arg = actual[0]
+
+        self.assertIsInstance(arg, Q)
+        self.assertEqual(arg.connector, Q.AND)
+        self.assertEqual(len(arg.children), 2)
+
+        # Can't guarantee the ordering of children, thus;
+        for child in arg.children:
+            if isinstance(child, tuple):
+                self.assertEqual(('desc', 'foo'), child)
+            elif isinstance(child, Q):
+                self.assertEqual(child.connector, Q.AND)
+                self.assertEqual(len(child.children), 2)
+                self.assertIn(('money', Money(0, 'USD')), child.children)
+                self.assertIn(('money_currency', 'USD'), child.children)
+            else:
+                self.fail("There should only be two elements, a tuple and a Q - not a %s" % child)
+
+        # Test
+        #   (OR: (AND: ('desc', 'foo'), ('money', 0 USD)), ('desc', 'bar'))
+        # results in:
+        #   (OR: (AND: ('desc', 'foo'), (AND: ('money', 0 USD), ('money_currency', u'USD'))), ('desc', 'bar'))
+        actual = _expand_money_args(ModelWithNonMoneyField(), [Q(money=Money(0, 'USD'), desc='foo') | Q(desc='bar')])
+
+        self.assertEqual(len(actual), 1)
+        arg = actual[0]
+
+        self.assertIsInstance(arg, Q)
+        self.assertEqual(arg.connector, Q.OR)
+        self.assertEqual(len(arg.children), 2)
+
+        # Can't guarantee the ordering of children, thus;
+        for child in arg.children:
+            if isinstance(child, tuple):
+                self.assertEqual(('desc', 'bar'), child)
+            elif isinstance(child, Q):
+                self.assertEqual(len(child.children), 2)
+                for subchild in child.children:
+                    if isinstance(subchild, tuple):
+                        self.assertEqual(('desc', 'foo'), subchild)
+                    elif isinstance(subchild, Q):
+                        self.assertIn(('money', Money(0, 'USD')), subchild.children)
+                        self.assertIn(('money_currency', 'USD'), subchild.children)
+            else:
+                self.fail("There should only be two elements, a tuple and a Q - not a %s" % child)
+
+        # Test
+        #   (OR: (OR: (AND: ('desc', 'foo'), ('money', 0 USD)), ('desc', 'eggs')), ('desc', 'bar'))
+        # results in;
+        #   (OR: (OR: (AND: ('desc', 'foo'), (AND: ('money', 0 USD), ('money_currency', u'USD'))), ('desc', 'eggs')), ('desc', 'bar'))
+        actual = _expand_money_args(ModelWithNonMoneyField(), [Q(Q(money=Money(0, 'USD'), desc='foo') | Q(desc='eggs')) | Q(desc='bar')])
+        arg = actual[0]
+
+        self.assertEqual(len(actual), 1)
+        self.assertIsInstance(arg, Q)
+        self.assertEqual(arg.connector, Q.OR)
+        self.assertEqual(len(arg.children), 2)
+
+        # Can't guarantee the ordering of children, thus;
+        for child in arg.children:
+            if isinstance(child, tuple):
+                self.assertEqual(('desc', 'bar'), child)
+            elif isinstance(child, Q):
+                self.assertEqual(len(child.children), 2)
+                for subchild in child.children:
+                    if isinstance(subchild, tuple):
+                        self.assertEqual(('desc', 'eggs'), subchild)
+                    elif isinstance(subchild, Q):
+                        for subsubchild in subchild.children:
+                            if isinstance(subsubchild, tuple):
+                                self.assertEqual(('desc', 'foo'), subsubchild)
+                            elif isinstance(subsubchild, Q):
+                                self.assertIn(('money', Money(0, 'USD')), subsubchild.children)
+                                self.assertIn(('money_currency', 'USD'), subsubchild.children)
+                            else:
+                                self.fail("There should only be two subsubchild elements, a tuple and a Q - not a %s" % subsubchild)
+                    else:
+                        self.fail("There should only be two subchild elements, a tuple and a Q - not a %s" % subsubchild)
+            else:
+                self.fail("There should only be two child elements, a tuple and a Q - not a %s" % child)

--- a/djmoney/tests/model_tests.py
+++ b/djmoney/tests/model_tests.py
@@ -12,37 +12,36 @@ from .testapp.models import (ModelWithVanillaMoneyField,
     ModelWithDefaultAsString, ModelWithDefaultAsStringWithCurrency, ModelWithDefaultAsMoney, ModelWithTwoMoneyFields,
     ProxyModel, ModelWithNonMoneyField)
 import moneyed
-from djmoney.models.managers import _expand_money_args
 
 
 class VanillaMoneyFieldTestCase(TestCase):
- 
+
     def testSaving(self):
-  
+
         somemoney = Money("100.0")
-  
+
         model = ModelWithVanillaMoneyField(money=somemoney)
         model.save()
-  
+
         retrieved = ModelWithVanillaMoneyField.objects.get(pk=model.pk)
-  
+
         self.assertEquals(somemoney.currency, retrieved.money.currency)
         self.assertEquals(somemoney, retrieved.money)
-  
+
         # Try setting the value directly
         retrieved.money = Money(1, moneyed.DKK)
         retrieved.save()
         retrieved = ModelWithVanillaMoneyField.objects.get(pk=model.pk)
-  
+
         self.assertEquals(Money(1, moneyed.DKK), retrieved.money)
-  
+
         object = BaseModel.objects.create()
         self.assertEquals(Money(0, 'USD'), object.first_field)
         object = BaseModel.objects.create(first_field='111.2')
         self.assertEquals(Money('111.2', 'USD'), object.first_field)
         object = BaseModel.objects.create(first_field=Money('123', 'PLN'))
         self.assertEquals(Money('123', 'PLN'), object.first_field)
-  
+
         object = ModelWithDefaultAsDecimal.objects.create()
         self.assertEquals(Money('0.01', 'CHF'), object.money)
         object = ModelWithDefaultAsInt.objects.create()
@@ -55,18 +54,18 @@ class VanillaMoneyFieldTestCase(TestCase):
         self.assertEquals(Money('12.05', 'PLN'), object.money)
         object = ModelWithDefaultAsMoney.objects.create()
         self.assertEquals(Money('0.01', 'RUB'), object.money)
-  
+
     def testRounding(self):
         somemoney = Money("100.0623456781123219")
-  
+
         model = ModelWithVanillaMoneyField(money=somemoney)
         model.save()
-  
+
         retrieved = ModelWithVanillaMoneyField.objects.get(pk=model.pk)
-          
+
         self.assertEquals(somemoney.currency, retrieved.money.currency)
         self.assertEquals(Money("100.06"), retrieved.money)
-  
+
     def testRelativeAddition(self):
         # test relative value adding
         somemoney = Money(100, 'USD')
@@ -81,132 +80,132 @@ class VanillaMoneyFieldTestCase(TestCase):
         mymodel.save()
         mymodel = ModelWithVanillaMoneyField.objects.get(pk=mymodel.pk)
         self.assertEquals(Money(0, 'USD'), mymodel.money)
- 
+
     def testComparisonLookup(self):
         ModelWithTwoMoneyFields.objects.create(amount1=Money(1, 'USD'), amount2=Money(2, 'USD'))
         ModelWithTwoMoneyFields.objects.create(amount1=Money(2, 'USD'), amount2=Money(0, 'USD'))
         ModelWithTwoMoneyFields.objects.create(amount1=Money(3, 'USD'), amount2=Money(0, 'USD'))
         ModelWithTwoMoneyFields.objects.create(amount1=Money(4, 'USD'), amount2=Money(0, 'GHS'))
         ModelWithTwoMoneyFields.objects.create(amount1=Money(5, 'USD'), amount2=Money(5, 'USD'))
- 
+
         qs = ModelWithTwoMoneyFields.objects.filter(amount1=F('amount2'))
         self.assertEquals(1, qs.count())
- 
+
         qs = ModelWithTwoMoneyFields.objects.filter(amount1__gt=F('amount2'))
         self.assertEquals(2, qs.count())
- 
+
         qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount2=Money(0, 'USD')))
         self.assertEquals(3, qs.count())
- 
+
         qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount1=Money(4, 'USD')) | Q(amount2=Money(0, 'GHS')))
         self.assertEquals(2, qs.count())
- 
+
         qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount1=Money(5, 'USD')) | Q(amount2=Money(0, 'GHS')))
         self.assertEquals(3, qs.count())
- 
+
         qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount1=Money(4, 'USD'), amount2=Money(0, 'GHS')))
         self.assertEquals(2, qs.count())
- 
+
         qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount1__gt=Money(4, 'USD'), amount2=Money(0, 'GHS')))
         self.assertEquals(1, qs.count())
- 
+
         qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount1__gte=Money(4, 'USD'), amount2=Money(0, 'GHS')))
         self.assertEquals(2, qs.count())
- 
+
     def testExactMatch(self):
-  
+
         somemoney = Money("100.0")
-  
+
         model = ModelWithVanillaMoneyField()
         model.money = somemoney
-  
+
         model.save()
-  
+
         retrieved = ModelWithVanillaMoneyField.objects.get(money=somemoney)
-  
+
         self.assertEquals(model.pk, retrieved.pk)
-  
+
     def testRangeSearch(self):
-  
+
         minMoney = Money("3")
-  
+
         model = ModelWithVanillaMoneyField(money=Money("100.0"))
-  
+
         model.save()
-  
+
         retrieved = ModelWithVanillaMoneyField.objects.get(money__gt=minMoney)
         self.assertEquals(model.pk, retrieved.pk)
-  
+
         shouldBeEmpty = ModelWithVanillaMoneyField.objects.filter(money__lt=minMoney)
         self.assertEquals(shouldBeEmpty.count(), 0)
-  
+
     def testCurrencySearch(self):
-  
+
         otherMoney = Money("1000", moneyed.USD)
         correctMoney = Money("1000", moneyed.ZWN)
-  
+
         model = ModelWithVanillaMoneyField(money=Money("100.0", moneyed.ZWN))
         model.save()
-  
+
         shouldBeEmpty = ModelWithVanillaMoneyField.objects.filter(money__lt=otherMoney)
         self.assertEquals(shouldBeEmpty.count(), 0)
-  
+
         shouldBeOne = ModelWithVanillaMoneyField.objects.filter(money__lt=correctMoney)
         self.assertEquals(shouldBeOne.count(), 1)
-  
+
     def testCurrencyChoices(self):
-  
+
         otherMoney = Money("1000", moneyed.USD)
         correctMoney = Money("1000", moneyed.ZWN)
-  
+
         model = ModelWithChoicesMoneyField(
             money=Money("100.0", moneyed.ZWN)
         )
         model.save()
-  
+
         shouldBeEmpty = ModelWithChoicesMoneyField.objects.filter(money__lt=otherMoney)
         self.assertEquals(shouldBeEmpty.count(), 0)
-  
+
         shouldBeOne = ModelWithChoicesMoneyField.objects.filter(money__lt=correctMoney)
         self.assertEquals(shouldBeOne.count(), 1)
-  
+
         model = ModelWithChoicesMoneyField(
             money=Money("100.0", moneyed.USD)
         )
         model.save()
-  
+
     def testIsNullLookup(self):
-  
+
         null_instance = NullMoneyFieldModel.objects.create(field=None)
         null_instance.save()
-  
+
         normal_instance = NullMoneyFieldModel.objects.create(field=Money(100, 'USD'))
         normal_instance.save()
-  
+
         shouldBeOne = NullMoneyFieldModel.objects.filter(field=None)
         self.assertEquals(shouldBeOne.count(), 1)
-  
+
     def testNullDefault(self):
         null_instance = NullMoneyFieldModel.objects.create()
         self.assertEquals(null_instance.field, None)
-  
-  
+
+
 class RelatedModelsTestCase(TestCase):
-  
+
     def testFindModelsRelatedToMoneyModels(self):
-  
+
         moneyModel = ModelWithVanillaMoneyField(money=Money("100.0", moneyed.ZWN))
         moneyModel.save()
-  
+
         relatedModel = ModelRelatedToModelWithMoney(moneyModel=moneyModel)
         relatedModel.save()
-  
+
         ModelRelatedToModelWithMoney.objects.get(moneyModel__money=Money("100.0", moneyed.ZWN))
         ModelRelatedToModelWithMoney.objects.get(moneyModel__money__lt=Money("1000.0", moneyed.ZWN))
 
 
 class NonMoneyTestCase(TestCase):
-  
+
     def testAllowExpressionNodesWithoutMoney(self):
         """ allow querying on expression nodes that are not Money """
         ModelWithNonMoneyField(money=Money(100.0), desc="hundred").save()
@@ -216,10 +215,10 @@ class NonMoneyTestCase(TestCase):
 
 class InheritedModelTestCase(TestCase):
     """Test inheritence from a concrete model"""
-  
+
     def testBaseModel(self):
         self.assertEqual(BaseModel.objects.model, BaseModel)
-  
+
     def testInheritedModel(self):
         self.assertEqual(InheritedModel.objects.model, InheritedModel)
         moneyModel = InheritedModel(
@@ -229,11 +228,11 @@ class InheritedModelTestCase(TestCase):
         moneyModel.save()
         self.assertEqual(moneyModel.first_field, Money(100.0, moneyed.ZWN))
         self.assertEqual(moneyModel.second_field, Money(200.0, moneyed.USD))
-  
-  
+
+
 class InheritorModelTestCase(TestCase):
     """Test inheritence from an ABSTRACT model"""
-  
+
     def testInheritorModel(self):
         self.assertEqual(InheritorModel.objects.model, InheritorModel)
         moneyModel = InheritorModel(
@@ -243,24 +242,24 @@ class InheritorModelTestCase(TestCase):
         moneyModel.save()
         self.assertEqual(moneyModel.price1, Money(100.0, moneyed.ZWN))
         self.assertEqual(moneyModel.price2, Money(200.0, moneyed.USD))
-  
-  
+
+
 class ManagerTest(TestCase):
-  
+
     def test_manager(self):
         self.assertTrue(hasattr(SimpleModel, 'objects'))
-  
+
     def test_objects_creation(self):
         SimpleModel.objects.create(money=Money("100.0", 'USD'))
         self.assertEqual(SimpleModel.objects.count(), 1)
 
-  
+
 class ProxyModelTest(TestCase):
-  
+
     def test_instances(self):
         ProxyModel.objects.create(money=Money("100.0", 'USD'))
         self.assertIsInstance(ProxyModel.objects.get(pk=1), ProxyModel)
-  
+
     def test_patching(self):
         ProxyModel.objects.create(money=Money("100.0", 'USD'))
         # This will fail if ProxyModel.objects doesn't have the patched manager:

--- a/djmoney/tests/model_tests.py
+++ b/djmoney/tests/model_tests.py
@@ -4,7 +4,7 @@ Created on May 7, 2011
 @author: jake
 '''
 from django.test import TestCase
-from django.db.models import F
+from django.db.models import F, Q
 from moneyed import Money
 from .testapp.models import (ModelWithVanillaMoneyField,
     ModelRelatedToModelWithMoney, ModelWithChoicesMoneyField, BaseModel, InheritedModel, InheritorModel,
@@ -12,36 +12,37 @@ from .testapp.models import (ModelWithVanillaMoneyField,
     ModelWithDefaultAsString, ModelWithDefaultAsStringWithCurrency, ModelWithDefaultAsMoney, ModelWithTwoMoneyFields,
     ProxyModel, ModelWithNonMoneyField)
 import moneyed
+from djmoney.models.managers import _expand_money_args
 
 
 class VanillaMoneyFieldTestCase(TestCase):
-
+ 
     def testSaving(self):
-
+  
         somemoney = Money("100.0")
-
+  
         model = ModelWithVanillaMoneyField(money=somemoney)
         model.save()
-
+  
         retrieved = ModelWithVanillaMoneyField.objects.get(pk=model.pk)
-
+  
         self.assertEquals(somemoney.currency, retrieved.money.currency)
         self.assertEquals(somemoney, retrieved.money)
-
+  
         # Try setting the value directly
         retrieved.money = Money(1, moneyed.DKK)
         retrieved.save()
         retrieved = ModelWithVanillaMoneyField.objects.get(pk=model.pk)
-
+  
         self.assertEquals(Money(1, moneyed.DKK), retrieved.money)
-
+  
         object = BaseModel.objects.create()
         self.assertEquals(Money(0, 'USD'), object.first_field)
         object = BaseModel.objects.create(first_field='111.2')
         self.assertEquals(Money('111.2', 'USD'), object.first_field)
         object = BaseModel.objects.create(first_field=Money('123', 'PLN'))
         self.assertEquals(Money('123', 'PLN'), object.first_field)
-
+  
         object = ModelWithDefaultAsDecimal.objects.create()
         self.assertEquals(Money('0.01', 'CHF'), object.money)
         object = ModelWithDefaultAsInt.objects.create()
@@ -54,18 +55,18 @@ class VanillaMoneyFieldTestCase(TestCase):
         self.assertEquals(Money('12.05', 'PLN'), object.money)
         object = ModelWithDefaultAsMoney.objects.create()
         self.assertEquals(Money('0.01', 'RUB'), object.money)
-
+  
     def testRounding(self):
         somemoney = Money("100.0623456781123219")
-
+  
         model = ModelWithVanillaMoneyField(money=somemoney)
         model.save()
-
+  
         retrieved = ModelWithVanillaMoneyField.objects.get(pk=model.pk)
-        
+          
         self.assertEquals(somemoney.currency, retrieved.money.currency)
         self.assertEquals(Money("100.06"), retrieved.money)
-
+  
     def testRelativeAddition(self):
         # test relative value adding
         somemoney = Money(100, 'USD')
@@ -80,123 +81,145 @@ class VanillaMoneyFieldTestCase(TestCase):
         mymodel.save()
         mymodel = ModelWithVanillaMoneyField.objects.get(pk=mymodel.pk)
         self.assertEquals(Money(0, 'USD'), mymodel.money)
-
+ 
     def testComparisonLookup(self):
         ModelWithTwoMoneyFields.objects.create(amount1=Money(1, 'USD'), amount2=Money(2, 'USD'))
         ModelWithTwoMoneyFields.objects.create(amount1=Money(2, 'USD'), amount2=Money(0, 'USD'))
         ModelWithTwoMoneyFields.objects.create(amount1=Money(3, 'USD'), amount2=Money(0, 'USD'))
         ModelWithTwoMoneyFields.objects.create(amount1=Money(4, 'USD'), amount2=Money(0, 'GHS'))
-
+        ModelWithTwoMoneyFields.objects.create(amount1=Money(5, 'USD'), amount2=Money(5, 'USD'))
+ 
+        qs = ModelWithTwoMoneyFields.objects.filter(amount1=F('amount2'))
+        self.assertEquals(1, qs.count())
+ 
         qs = ModelWithTwoMoneyFields.objects.filter(amount1__gt=F('amount2'))
         self.assertEquals(2, qs.count())
-
+ 
+        qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount2=Money(0, 'USD')))
+        self.assertEquals(3, qs.count())
+ 
+        qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount1=Money(4, 'USD')) | Q(amount2=Money(0, 'GHS')))
+        self.assertEquals(2, qs.count())
+ 
+        qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount1=Money(5, 'USD')) | Q(amount2=Money(0, 'GHS')))
+        self.assertEquals(3, qs.count())
+ 
+        qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount1=Money(4, 'USD'), amount2=Money(0, 'GHS')))
+        self.assertEquals(2, qs.count())
+ 
+        qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount1__gt=Money(4, 'USD'), amount2=Money(0, 'GHS')))
+        self.assertEquals(1, qs.count())
+ 
+        qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount1__gte=Money(4, 'USD'), amount2=Money(0, 'GHS')))
+        self.assertEquals(2, qs.count())
+ 
     def testExactMatch(self):
-
+  
         somemoney = Money("100.0")
-
+  
         model = ModelWithVanillaMoneyField()
         model.money = somemoney
-
+  
         model.save()
-
+  
         retrieved = ModelWithVanillaMoneyField.objects.get(money=somemoney)
-
+  
         self.assertEquals(model.pk, retrieved.pk)
-
+  
     def testRangeSearch(self):
-
+  
         minMoney = Money("3")
-
+  
         model = ModelWithVanillaMoneyField(money=Money("100.0"))
-
+  
         model.save()
-
+  
         retrieved = ModelWithVanillaMoneyField.objects.get(money__gt=minMoney)
         self.assertEquals(model.pk, retrieved.pk)
-
+  
         shouldBeEmpty = ModelWithVanillaMoneyField.objects.filter(money__lt=minMoney)
         self.assertEquals(shouldBeEmpty.count(), 0)
-
+  
     def testCurrencySearch(self):
-
+  
         otherMoney = Money("1000", moneyed.USD)
         correctMoney = Money("1000", moneyed.ZWN)
-
+  
         model = ModelWithVanillaMoneyField(money=Money("100.0", moneyed.ZWN))
         model.save()
-
+  
         shouldBeEmpty = ModelWithVanillaMoneyField.objects.filter(money__lt=otherMoney)
         self.assertEquals(shouldBeEmpty.count(), 0)
-
+  
         shouldBeOne = ModelWithVanillaMoneyField.objects.filter(money__lt=correctMoney)
         self.assertEquals(shouldBeOne.count(), 1)
-
+  
     def testCurrencyChoices(self):
-
+  
         otherMoney = Money("1000", moneyed.USD)
         correctMoney = Money("1000", moneyed.ZWN)
-
+  
         model = ModelWithChoicesMoneyField(
             money=Money("100.0", moneyed.ZWN)
         )
         model.save()
-
+  
         shouldBeEmpty = ModelWithChoicesMoneyField.objects.filter(money__lt=otherMoney)
         self.assertEquals(shouldBeEmpty.count(), 0)
-
+  
         shouldBeOne = ModelWithChoicesMoneyField.objects.filter(money__lt=correctMoney)
         self.assertEquals(shouldBeOne.count(), 1)
-
+  
         model = ModelWithChoicesMoneyField(
             money=Money("100.0", moneyed.USD)
         )
         model.save()
-
+  
     def testIsNullLookup(self):
-
+  
         null_instance = NullMoneyFieldModel.objects.create(field=None)
         null_instance.save()
-
+  
         normal_instance = NullMoneyFieldModel.objects.create(field=Money(100, 'USD'))
         normal_instance.save()
-
+  
         shouldBeOne = NullMoneyFieldModel.objects.filter(field=None)
         self.assertEquals(shouldBeOne.count(), 1)
-
+  
     def testNullDefault(self):
         null_instance = NullMoneyFieldModel.objects.create()
         self.assertEquals(null_instance.field, None)
-
-
+  
+  
 class RelatedModelsTestCase(TestCase):
-
+  
     def testFindModelsRelatedToMoneyModels(self):
-
+  
         moneyModel = ModelWithVanillaMoneyField(money=Money("100.0", moneyed.ZWN))
         moneyModel.save()
-
+  
         relatedModel = ModelRelatedToModelWithMoney(moneyModel=moneyModel)
         relatedModel.save()
-
+  
         ModelRelatedToModelWithMoney.objects.get(moneyModel__money=Money("100.0", moneyed.ZWN))
         ModelRelatedToModelWithMoney.objects.get(moneyModel__money__lt=Money("1000.0", moneyed.ZWN))
-
-
+  
+  
 class NonMoneyTestCase(TestCase):
-
+  
     def testAllowExpressionNodesWithoutMoney(self):
         """ allow querying on expression nodes that are not Money """
         ModelWithNonMoneyField(money=Money(100.0), desc="hundred").save()
         instance = ModelWithNonMoneyField.objects.filter(desc=F("desc")).get()
         self.assertEqual(instance.desc, "hundred")
-
-
+  
+  
 class InheritedModelTestCase(TestCase):
     """Test inheritence from a concrete model"""
-
+  
     def testBaseModel(self):
         self.assertEqual(BaseModel.objects.model, BaseModel)
-
+  
     def testInheritedModel(self):
         self.assertEqual(InheritedModel.objects.model, InheritedModel)
         moneyModel = InheritedModel(
@@ -206,11 +229,11 @@ class InheritedModelTestCase(TestCase):
         moneyModel.save()
         self.assertEqual(moneyModel.first_field, Money(100.0, moneyed.ZWN))
         self.assertEqual(moneyModel.second_field, Money(200.0, moneyed.USD))
-
-
+  
+  
 class InheritorModelTestCase(TestCase):
     """Test inheritence from an ABSTRACT model"""
-
+  
     def testInheritorModel(self):
         self.assertEqual(InheritorModel.objects.model, InheritorModel)
         moneyModel = InheritorModel(
@@ -220,24 +243,24 @@ class InheritorModelTestCase(TestCase):
         moneyModel.save()
         self.assertEqual(moneyModel.price1, Money(100.0, moneyed.ZWN))
         self.assertEqual(moneyModel.price2, Money(200.0, moneyed.USD))
-
-
+  
+  
 class ManagerTest(TestCase):
-
+  
     def test_manager(self):
         self.assertTrue(hasattr(SimpleModel, 'objects'))
-
+  
     def test_objects_creation(self):
         SimpleModel.objects.create(money=Money("100.0", 'USD'))
         self.assertEqual(SimpleModel.objects.count(), 1)
-
-
+  
+  
 class ProxyModelTest(TestCase):
-
+  
     def test_instances(self):
         ProxyModel.objects.create(money=Money("100.0", 'USD'))
         self.assertIsInstance(ProxyModel.objects.get(pk=1), ProxyModel)
-
+  
     def test_patching(self):
         ProxyModel.objects.create(money=Money("100.0", 'USD'))
         # This will fail if ProxyModel.objects doesn't have the patched manager:

--- a/djmoney/tests/model_tests.py
+++ b/djmoney/tests/model_tests.py
@@ -203,8 +203,8 @@ class RelatedModelsTestCase(TestCase):
   
         ModelRelatedToModelWithMoney.objects.get(moneyModel__money=Money("100.0", moneyed.ZWN))
         ModelRelatedToModelWithMoney.objects.get(moneyModel__money__lt=Money("1000.0", moneyed.ZWN))
-  
-  
+
+
 class NonMoneyTestCase(TestCase):
   
     def testAllowExpressionNodesWithoutMoney(self):
@@ -212,8 +212,8 @@ class NonMoneyTestCase(TestCase):
         ModelWithNonMoneyField(money=Money(100.0), desc="hundred").save()
         instance = ModelWithNonMoneyField.objects.filter(desc=F("desc")).get()
         self.assertEqual(instance.desc, "hundred")
-  
-  
+
+
 class InheritedModelTestCase(TestCase):
     """Test inheritence from a concrete model"""
   
@@ -253,7 +253,7 @@ class ManagerTest(TestCase):
     def test_objects_creation(self):
         SimpleModel.objects.create(money=Money("100.0", 'USD'))
         self.assertEqual(SimpleModel.objects.count(), 1)
-  
+
   
 class ProxyModelTest(TestCase):
   

--- a/djmoney/tests/model_tests.py
+++ b/djmoney/tests/model_tests.py
@@ -10,7 +10,7 @@ from .testapp.models import (ModelWithVanillaMoneyField,
     ModelRelatedToModelWithMoney, ModelWithChoicesMoneyField, BaseModel, InheritedModel, InheritorModel,
     SimpleModel, NullMoneyFieldModel, ModelWithDefaultAsDecimal, ModelWithDefaultAsFloat, ModelWithDefaultAsInt,
     ModelWithDefaultAsString, ModelWithDefaultAsStringWithCurrency, ModelWithDefaultAsMoney, ModelWithTwoMoneyFields,
-    ProxyModel)
+    ProxyModel, ModelWithNonMoneyField)
 import moneyed
 
 
@@ -180,6 +180,15 @@ class RelatedModelsTestCase(TestCase):
 
         ModelRelatedToModelWithMoney.objects.get(moneyModel__money=Money("100.0", moneyed.ZWN))
         ModelRelatedToModelWithMoney.objects.get(moneyModel__money__lt=Money("1000.0", moneyed.ZWN))
+
+
+class NonMoneyTestCase(TestCase):
+
+    def testAllowExpressionNodesWithoutMoney(self):
+        """ allow querying on expression nodes that are not Money """
+        ModelWithNonMoneyField(money=Money(100.0), desc="hundred").save()
+        instance = ModelWithNonMoneyField.objects.filter(desc=F("desc")).get()
+        self.assertEqual(instance.desc, "hundred")
 
 
 class InheritedModelTestCase(TestCase):

--- a/djmoney/tests/money_patched.py
+++ b/djmoney/tests/money_patched.py
@@ -2,9 +2,17 @@
 from moneyed import test_moneyed_classes
 from djmoney.models.fields import MoneyPatched
 
+
+class TestDjangoMoney(test_moneyed_classes.TestMoney):
+
+    # MoneyPatched localizes to 'en_US', removing "US" from the default
+    # py-moneyed prefix, 'US$'. This breaks py-moneyed's test_str.
+    def test_str(self):
+        assert str(self.one_million_bucks) == '$1,000,000.00'
+
 # replace class "Money" a class "MoneyPath"
 test_moneyed_classes.Money = MoneyPatched
 
 TestCurrency = test_moneyed_classes.TestCurrency
 
-TestMoney = test_moneyed_classes.TestMoney
+TestMoney = TestDjangoMoney

--- a/djmoney/tests/testapp/models.py
+++ b/djmoney/tests/testapp/models.py
@@ -51,6 +51,11 @@ class ModelWithChoicesMoneyField(models.Model):
     )
 
 
+class ModelWithNonMoneyField(models.Model):
+    money = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
+    desc = models.CharField(max_length=10)
+
+
 class AbstractModel(models.Model):
     price1 = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
 


### PR DESCRIPTION
Patches the remaining broken specs from @alexhayes's [feature/101 branch.](https://github.com/alexhayes/django-money/tree/feature/101) I'm new to Python and Django, so let me know if there is a better way to fix the problems with localization in the specs. More details on the localization problems in my comments: https://github.com/django-money/django-money/issues/101#issuecomment-103927272

This should be green - let's see what Travis CI says!