### PR TITLE
re #128 patch deconstruct.

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -357,7 +357,7 @@ class MoneyField(models.DecimalField):
         if self.default is not None:
             kwargs['default'] = self.default.amount
         if self.default_currency != DEFAULT_CURRENCY:
-            kwargs['default_currency'] = '%s' % self.default_currency
+            kwargs['default_currency'] = '%s' % str(self.default_currency)
         if self.currency_choices != CURRENCY_CHOICES:
             kwargs['currency_choices'] = self.currency_choices
         return name, path, args, kwargs

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -357,7 +357,7 @@ class MoneyField(models.DecimalField):
         if self.default is not None:
             kwargs['default'] = self.default.amount
         if self.default_currency != DEFAULT_CURRENCY:
-            kwargs['default_currency'] = '%s' % str(self.default_currency)
+            kwargs['default_currency'] = str(self.default_currency)
         if self.currency_choices != CURRENCY_CHOICES:
             kwargs['currency_choices'] = self.currency_choices
         return name, path, args, kwargs

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -354,10 +354,10 @@ class MoneyField(models.DecimalField):
     def deconstruct(self):
         name, path, args, kwargs = super(MoneyField, self).deconstruct()
 
-        if self.default:
+        if self.default is not None:
             kwargs['default'] = self.default.amount
         if self.default_currency != DEFAULT_CURRENCY:
-            kwargs['default_currency'] = self.default_currency
+            kwargs['default_currency'] = '%s' % self.default_currency
         if self.currency_choices != CURRENCY_CHOICES:
             kwargs['currency_choices'] = self.currency_choices
         return name, path, args, kwargs


### PR DESCRIPTION
With `Django 1.8.4` deserialization does not work in migrations as:
- `self.default` with a 0 dollar value returns False there for not
updating the amount correctly.
- The default currency returns an object that cannot be serialized.
Transforming it into a string works.