### PR TITLE
Better check on None value in decompress

### DIFF
--- a/djmoney/forms/widgets.py
+++ b/djmoney/forms/widgets.py
@@ -28,7 +28,7 @@ class MoneyWidget(MultiWidget):
         super(MoneyWidget, self).__init__(widgets, *args, **kwargs)
 
     def decompress(self, value):
-        if value:
+        if value is not None:
             return [value.amount, value.currency]
         return [None, None]
 


### PR DESCRIPTION
In limist/py-moneyed@03768f6205e0829c98f0497938dca79ccd335743 was added `Money.__nonzero__`, which evaluates to `bool(self.amount)`.
So, if you have `default` argument for `MoneyField` with `amount` equal to 0, then `decompress` will return `[None, None]`, which is look like there is no `default` at all. 
If you change this `if` to check `None`-ness of value, then old behavior remains