### PR TITLE
Fix field has changed

### DIFF
--- a/djmoney/tests/form_tests.py
+++ b/djmoney/tests/form_tests.py
@@ -10,7 +10,7 @@ import moneyed
 from django.test import TestCase
 from moneyed import Money
 
-from .testapp.forms import MoneyForm, OptionalMoneyForm, MoneyModelForm
+from .testapp.forms import MoneyForm, OptionalMoneyForm, MoneyModelForm, MoneyFormMultipleCurrencies
 from .testapp.models import ModelWithVanillaMoneyField
 
 
@@ -58,6 +58,21 @@ class MoneyFormTestCase(TestCase):
         # But if user types something it, it should be noticed:
         form2 = MoneyForm({"money_0": "1.23", "money_1": moneyed.SEK})
         self.assertEquals(form2.changed_data, ['money'])
+
+
+class MoneyFormMultipleCurrenciesTestCase(TestCase):
+
+    def testChangeCurrencyNotAmount(self):
+        # If the amount is the same, but the currency changes, then we
+        # should consider this to be a change.
+        initial_money = Money(Decimal(10), moneyed.SEK)
+        new_money = Money(Decimal(10), moneyed.EUR)
+
+        initial = {'money': initial_money}
+        data = {'money_0': new_money.amount, 'money_1': new_money.currency}
+
+        form = MoneyFormMultipleCurrencies(data, initial=initial)
+        self.assertEquals(form.changed_data, ['money'])
 
 
 class OptionalMoneyFormTestCase(TestCase):

--- a/djmoney/tests/testapp/forms.py
+++ b/djmoney/tests/testapp/forms.py
@@ -13,6 +13,10 @@ class MoneyForm(forms.Form):
 
     money = MoneyField(currency_choices=[(u'SEK', u'Swedish Krona')], max_value=1000, min_value=2)
 
+class MoneyFormMultipleCurrencies(forms.Form):
+
+    money = MoneyField(currency_choices=[(u'SEK', u'Swedish Krona'), (u'EUR', u'Euro')], max_value=1000, min_value=2)
+
 class OptionalMoneyForm(forms.Form):
 
     money = MoneyField(required=False, currency_choices=[(u'SEK', u'Swedish Krona')])


### PR DESCRIPTION
Fixes #112 (I believe)

Changing the currency but leaving the amount the same was not considered a change, meaning that it wasn't being saved - I've added a test for this.

Had to do some tweaks, as the existing solution had been implemented so that inline forms in formsets (eg in admin) worked correctly when empty - there was an existing test for this.

Edit: pushed just failing test, waiting for travis to start for each environment. Will push fix when(?!) failing test fails on travis.