### PR TITLE
Fix tests for python2.6 and run on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ install: pip install tox
 script: tox -e $ENV
 matrix:
   include:
+    - python: "2.6"
+      env: ENV=py26-django15-pm05
+    - python: "2.6"
+      env: ENV=py26-django16-pm05
     - python: "2.7"
       env: ENV=py27-django15-pm05
     - python: "2.7"

--- a/djmoney/tests/model_tests.py
+++ b/djmoney/tests/model_tests.py
@@ -6,7 +6,11 @@ Created on May 7, 2011
 from decimal import Decimal
 from django.test import TestCase
 from django.db.models import F, Q
-from unittest import skipIf
+try:
+    from unittest import skipIf
+except ImportError:
+    # For python2.6 compatibility
+    from unittest2 import skipIf
 from moneyed import Money
 from .testapp.models import (ModelWithVanillaMoneyField,
     ModelRelatedToModelWithMoney, ModelWithChoicesMoneyField, BaseModel, InheritedModel, InheritorModel,


### PR DESCRIPTION
`tox` was failing even once I had installed `python2.6`. So now - I think - tox should either pass or give you a `InterpreterNotFound`.

I also added two more environments for travis. Based on:
> Django 1.6 will be the final release series to support Python 2.6; beginning with Django 1.7, the minimum supported Python version will be 2.7.

I've only added these tests for Django 1.5 and 1.6.

(from https://docs.djangoproject.com/en/1.8/releases/1.6/#python-compatibility)

Also, there are no tests for Django 1.4 run on travis. (Though perhaps we don't want too many tests run on travis, in which case maybe my change here adding more tests is bad?)