### PR TITLE
Sort CURRENCY_CHOICES by name then by code #146

### DIFF
--- a/djmoney/settings.py
+++ b/djmoney/settings.py
@@ -19,4 +19,4 @@ else:
     CURRENCY_CHOICES = [(c.code, c.name) for i, c in CURRENCIES.items() if
                         c.code != DEFAULT_CURRENCY_CODE]
 
-CURRENCY_CHOICES.sort(key=operator.itemgetter(1))
+CURRENCY_CHOICES.sort(key=operator.itemgetter(1, 0))


### PR DESCRIPTION
As CURRENCY_CHOICES may have multiple currency codes with the same name, we must sort by name then code otherwise the order is not reliable which then causes problems with django migrations

Fixes #146 