### PR TITLE
Fix for get_or_create / create manager methods not respecting currenc…

### DIFF
--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -40,11 +40,6 @@ def _get_clean_name(name):
 
 
 def _get_field(model, name):
-    if django.VERSION[0] >= 1 and django.VERSION[1] >= 8:
-        # Django 1.8+ - can use something like 
-        # expression.output_field.get_internal_field() == 'Money..'
-        raise NotImplementedError("Django 1.8+ support is not implemented.")
-
     from django.db.models.fields import FieldDoesNotExist
 
     # Create a fake query object so we can easily work out what field
@@ -127,7 +122,10 @@ def _expand_money_kwargs(model, kwargs):
             to_append[name] = value.amount
             to_append[get_currency_field_name(clean_name)] = smart_unicode(
                 value.currency)
-        if isinstance(value, BaseExpression):
+        cmp_cls = BaseExpression
+        if django.VERSION >= (1, 8):
+            cmp_cls = F
+        if isinstance(value, cmp_cls):
             field = _get_field(model, name)
             if isinstance(field, MoneyField):
                 clean_name = _get_clean_name(name)

--- a/djmoney/tests/model_tests.py
+++ b/djmoney/tests/model_tests.py
@@ -105,8 +105,8 @@ class VanillaMoneyFieldTestCase(TestCase):
         self.assertEquals(1, qs.count())
 
         qs = ModelWithTwoMoneyFields.objects.filter(amount1__gt=F('amount2'))
-        # should yield 2 USD, 3 USD, 4 USD
-        self.assertEquals(3, qs.count())
+        # should yield 2 USD, 3 USD, but not 4 GHS (different currency)
+        self.assertEquals(2, qs.count())
 
         qs = ModelWithTwoMoneyFields.objects.filter(Q(amount1=Money(1, 'USD')) | Q(amount2=Money(0, 'USD')))
         self.assertEquals(3, qs.count())

--- a/djmoney/tests/model_tests.py
+++ b/djmoney/tests/model_tests.py
@@ -203,6 +203,19 @@ class VanillaMoneyFieldTestCase(TestCase):
         null_instance = NullMoneyFieldModel.objects.create()
         self.assertEquals(null_instance.field, None)
 
+    def test_get_or_create_respects_currency(self):
+        instance, created = ModelWithVanillaMoneyField.objects.get_or_create(
+            money_currency='PLN'
+        )
+
+        self.assertEquals(str(instance.money.currency), 'PLN', 'currency should be taken into account in get_or_create')
+
+        instance, created = ModelWithVanillaMoneyField.objects.get_or_create(
+            money=Money(0, 'EUR')
+        )
+
+        self.assertEquals(str(instance.money.currency), 'EUR', 'currency should be taken into account in get_or_create')
+
 
 class RelatedModelsTestCase(TestCase):
 

--- a/djmoney/tests/reversion_tests.py
+++ b/djmoney/tests/reversion_tests.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from testapp.models import RevisionedModel
+from djmoney.tests.testapp.models import RevisionedModel
 from moneyed import Money
 from django import VERSION
 if VERSION >= (1, 7):

--- a/djmoney/tests/reversion_tests.py
+++ b/djmoney/tests/reversion_tests.py
@@ -1,7 +1,11 @@
 from django.test import TestCase
 from testapp.models import RevisionedModel
 from moneyed import Money
-import reversion
+from django import VERSION
+if VERSION >= (1, 7):
+    from reversion import revisions as reversion
+else:
+    import reversion
 
 
 class ReversionTestCase(TestCase):

--- a/djmoney/tests/testapp/models.py
+++ b/djmoney/tests/testapp/models.py
@@ -10,6 +10,12 @@ from django.db import models
 import moneyed
 from decimal import Decimal
 
+from django import VERSION
+if VERSION >= (1, 7):
+    from reversion import revisions as reversion
+else:
+    import reversion
+
 
 class ModelWithVanillaMoneyField(models.Model):
     money = MoneyField(max_digits=10, decimal_places=2)
@@ -73,7 +79,6 @@ class InheritorModel(AbstractModel):
 class RevisionedModel(models.Model):
     amount = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
 
-import reversion
 reversion.register(RevisionedModel)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,13 +44,13 @@ commands = {envpython} runtests.py {posargs}
        south>=0.8.2
 1.7.x  =
        Django==1.7.8
-       django-reversion==1.8.5
+       django-reversion==1.10.0
 1.8.x  =
        Django==1.8.2
-       django-reversion==1.8.5
+       django-reversion==1.10.0
 1.9.x  =
        Django==1.9.1
-       django-reversion==1.9.3
+       django-reversion==1.10.0
 master =
        https://github.com/django/django/tarball/master
        django-reversion==1.8.5


### PR DESCRIPTION
…y code.

For instance, when you would do:

`mymodel, created = Model.objects.get_or_create(money_currency='EUR')`

and your model would have default_currency set to XYZ then the mymodel
instance would have the currency set to XYZ, despite the fact that you
have set it to EUR. This has to do with the fact that the currency field
has a lower creation counter than the basic money field itself.

This patch solves this problem.