### PR TITLE
Extend F expressions support. Closes #167

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 python:
   - 3.5
-install: pip install tox codecov
+install: travis_retry pip install "virtualenv<14.0.0" tox codecov
 script: tox -e $TOX_ENV
 env:
   - TOX_ENV=django_master-py35

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 	@echo "coverage - check code coverage quickly with the default Python"
 	@echo "install - install the package to the active Python's site-packages"
 
-clean: clean-build clean-pyc clean-test
+clean: clean-test clean-build clean-pyc
 
 clean-build:
 	rm -fr build/

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -150,6 +150,42 @@ class MoneyPatched(Money):
                           self.currency)
 
 
+def get_value(obj, expr):
+    """
+    Extracts value from object or expression.
+    """
+    if isinstance(expr, F):
+        expr = getattr(obj, expr.name)
+    elif hasattr(expr, 'value'):
+        expr = expr.value
+    return expr
+
+
+def validate_money_expression(obj, expr):
+    """
+    Money supports different types of expressions, but you can't do following:
+      - Add or subtract money with not-money
+      - Any exponentiation
+      - Any operations with money in different currencies
+      - Multiplication, division, modulo with money instances on both sides of expression
+    """
+    if VERSION < (1, 8):
+        lhs, rhs = expr.children
+    else:
+        lhs, rhs = expr.lhs, expr.rhs
+    connector = expr.connector
+    lhs = get_value(obj, lhs)
+    rhs = get_value(obj, rhs)
+
+    if (not isinstance(rhs, Money) and connector in ('+', '-')) or connector == '^':
+        raise ValueError('Invalid F expression for MoneyField')
+    if isinstance(lhs, Money) and isinstance(rhs, Money):
+        if connector in ('*', '/', '^', '%%'):
+            raise ValueError('Invalid F expression for MoneyField')
+        if lhs.currency != rhs.currency:
+            raise ValueError('You cannot use F() with different currencies.')
+
+
 class MoneyFieldProxy(object):
     def __init__(self, field):
         self.field = field
@@ -193,24 +229,17 @@ class MoneyFieldProxy(object):
                         obj, self.currency_field_name,
                         smart_unicode(value.currency))
         elif isinstance(value, BaseExpression):
-            # we can only allow this operation if the currency matches.
-            # otherwise, one could use F() with different currencies
-            # which should not be possible.
-            def _check_currency(obj, field, amt):
-                currency_field_name = get_currency_field_name(field.name)
-                if obj.__dict__[currency_field_name] != str(amt.currency):
-                    raise ValueError(
-                        'You cannot use F() with different currencies.')
+            if isinstance(value, (F, BaseExpression)):
+                validate_money_expression(obj, value)
+
             if VERSION < (1, 8):
                 rhs = value.children[1]
                 if not isinstance(rhs, F) and isinstance(rhs, Money):
-                    _check_currency(obj, self.field, rhs)
                     # Django 1.8 removed `children` attribute.
                     value.children[1] = rhs.amount
             else:
                 rhs = value.rhs
                 if not isinstance(rhs, F) and isinstance(rhs.value, Money):
-                    _check_currency(obj, self.field, rhs.value)
                     # value.lhs contains F expression, i.e.
                     # F(field)
                     # rhs contains our value, however we need to extract the amount

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -114,6 +114,7 @@ class TestVanillaMoneyField:
         instance = ModelWithVanillaMoneyField.objects.get(pk=instance.pk)
         assert instance.money == expected
 
+    @pytest.mark.skipif(VERSION < (1, 5), reason='Django < 1.5 does not support `update_fields` kwarg')
     def test_f_queries_with_update_fields(self):
         instance = ModelWithVanillaMoneyField.objects.create(money=Money(100, 'USD'), integer=2)
         instance.money = F('money') + Money(100, 'USD')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -114,6 +114,13 @@ class TestVanillaMoneyField:
         instance = ModelWithVanillaMoneyField.objects.get(pk=instance.pk)
         assert instance.money == expected
 
+    def test_f_queries_with_update_fields(self):
+        instance = ModelWithVanillaMoneyField.objects.create(money=Money(100, 'USD'), integer=2)
+        instance.money = F('money') + Money(100, 'USD')
+        instance.save(update_fields=['money'])
+        instance = ModelWithVanillaMoneyField.objects.get(pk=instance.pk)
+        assert instance.money == Money(200, 'USD')
+
     INVALID_EXPRESSIONS = [
         F('money') + Money(100, 'EUR'),
         F('money') * F('money'),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -83,7 +83,7 @@ class TestVanillaMoneyField:
 
         assert retrieved.money == Money('100.06')
 
-    @pytest.mark.parametrize(
+    parametrize_f_objects = pytest.mark.parametrize(
         'f_obj, expected',
         (
             (F('money') + Money(100, 'USD'), Money(200, 'USD')),
@@ -91,11 +91,14 @@ class TestVanillaMoneyField:
             (F('money') * 2, Money(200, 'USD')),
             (F('money') * F('integer'), Money(200, 'USD')),
             (F('money') / 2, Money(50, 'USD')),
+            (F('money') % 98, Money(2, 'USD')),
             (F('money') / F('integer'), Money(50, 'USD')),
             (F('money') + F('money'), Money(200, 'USD')),
             (F('money') - F('money'), Money(0, 'USD')),
         )
     )
+
+    @parametrize_f_objects
     def test_f_queries(self, f_obj, expected):
         instance = ModelWithVanillaMoneyField.objects.create(money=Money(100, 'USD'), integer=2)
         instance.money = f_obj
@@ -103,12 +106,31 @@ class TestVanillaMoneyField:
         instance = ModelWithVanillaMoneyField.objects.get(pk=instance.pk)
         assert instance.money == expected
 
-    def test_different_currencies(self):
+    @parametrize_f_objects
+    def test_f_queries_update(self, f_obj, expected):
+        instance = ModelWithVanillaMoneyField.objects.create(money=Money(100, 'USD'), integer=2)
+        ModelWithVanillaMoneyField.objects.update(money=f_obj)
+        instance = ModelWithVanillaMoneyField.objects.get(pk=instance.pk)
+        assert instance.money == expected
+
+    @pytest.mark.parametrize(
+        'f_obj',
+        (
+            F('money') + Money(100, 'EUR'),
+            F('money') * F('money'),
+            F('money') / F('money'),
+            F('money') % F('money'),
+            F('money') ** F('money'),
+            F('money') ** F('integer'),
+            F('money') + F('integer'),
+            F('money') + F('second_money'),
+            F('money') ** 2,
+        )
+    )
+    def test_invalid_expressions(self, f_obj):
         instance = ModelWithVanillaMoneyField.objects.create(money=Money(100, 'USD'))
-        # check that one cannot use different currencies with F()
         with pytest.raises(ValueError):
-            # this model has USD as a currency, therefore this should fail.
-            instance.money = F('money') + Money(100, 'EUR')
+            instance.money = f_obj
 
     @pytest.mark.parametrize(
         'filters, expected_count',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -88,12 +88,16 @@ class TestVanillaMoneyField:
         (
             (F('money') + Money(100, 'USD'), Money(200, 'USD')),
             (F('money') - Money(100, 'USD'), Money(0, 'USD')),
-            pytest.mark.xfail((F('money') * 2, Money(200, 'USD')), reason='Multiplication is not implemented'),
-            pytest.mark.xfail((F('money') / 2, Money(50, 'USD')), reason='Division is not implemented'),
+            (F('money') * 2, Money(200, 'USD')),
+            (F('money') * F('integer'), Money(200, 'USD')),
+            (F('money') / 2, Money(50, 'USD')),
+            (F('money') / F('integer'), Money(50, 'USD')),
+            (F('money') + F('money'), Money(200, 'USD')),
+            (F('money') - F('money'), Money(0, 'USD')),
         )
     )
     def test_f_queries(self, f_obj, expected):
-        instance = ModelWithVanillaMoneyField.objects.create(money=Money(100, 'USD'))
+        instance = ModelWithVanillaMoneyField.objects.create(money=Money(100, 'USD'), integer=2)
         instance.money = f_obj
         instance.save()
         instance = ModelWithVanillaMoneyField.objects.get(pk=instance.pk)

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -17,6 +17,7 @@ from .._compat import reversion
 
 class ModelWithVanillaMoneyField(models.Model):
     money = MoneyField(max_digits=10, decimal_places=2)
+    integer = models.IntegerField(default=0)
 
 
 class ModelWithDefaultAsInt(models.Model):

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -17,6 +17,7 @@ from .._compat import reversion
 
 class ModelWithVanillaMoneyField(models.Model):
     money = MoneyField(max_digits=10, decimal_places=2)
+    second_money = MoneyField(max_digits=10, decimal_places=2, default_currency='EUR')
     integer = models.IntegerField(default=0)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,15 +7,6 @@ envlist =
     django14-py{27,26,py}
 
 [testenv]
-basepython =
-    py26: python2.6
-    py27: python2.7
-    py32: python3.2
-    py33: python3.3
-    py34: python3.4
-    py35: python3.5
-    pypy: pypy
-    pypy3: pypy3
 deps =
     django14: {[django]1.4.x}
     django15: {[django]1.5.x}


### PR DESCRIPTION
I want to add some checks. For such cases:
```python
F('money_field') * F('money_field')
```
We can't multiply money instances, but now it is possible to do that, because it is numeric fields.
Also I'll check F expressions in `.update()`