### PR TITLE
Fix access to manager via model instances. Closes #86. Closes #87.

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -467,8 +467,10 @@ def patch_managers(sender, **kwargs):
     from .managers import money_manager
 
     if hasattr(sender._meta, 'has_money_field'):
-        for _id, name, manager in sender._meta.concrete_managers:
-            setattr(sender, name, money_manager(manager))
+        sender.copy_managers([
+            (_id, name, money_manager(manager))
+            for _id, name, manager in sender._meta.concrete_managers
+        ])
 
 
 class_prepared.connect(patch_managers)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,6 +17,7 @@ from moneyed import Money
 from djmoney.models.fields import AUTO_CONVERT_MONEY, MoneyPatched
 
 from .testapp.models import (
+    AbstractModel,
     BaseModel,
     InheritedModel,
     InheritorModel,
@@ -367,3 +368,17 @@ class TestDifferentCurrencies:
     def test_exception(self):
         with pytest.raises(TypeError):
             MoneyPatched(10, 'EUR') == Money(10, 'USD')
+
+
+@pytest.mark.parametrize(
+    'model_class', (
+        AbstractModel,
+        ModelWithNonMoneyField,
+        InheritorModel,
+        InheritedModel,
+        ProxyModel,
+    )
+)
+def test_manager_instance_access(model_class):
+    with pytest.raises(AttributeError):
+        model_class().objects.all()


### PR DESCRIPTION
Managers should not be accessible via model instances.