### PR TITLE
Fixed m2m data loss for Django < 1.8. Closes #184

### DIFF
--- a/djmoney/_compat.py
+++ b/djmoney/_compat.py
@@ -56,3 +56,14 @@ def set_expression_rhs(expr, value):
         expr.children[1] = value
     else:
         expr.rhs.value = value
+
+
+def get_fields(model):
+    """
+    Returns a set of fields associated to the model.
+    """
+    opts = model._meta
+    if VERSION < (1, 8):
+        return opts.get_all_field_names()
+    else:
+        return set(field.name for field in opts.get_fields())

--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -11,8 +11,9 @@ from django.utils import six
 
 from moneyed import Money
 
-from djmoney.models.fields import MoneyField
-from djmoney.utils import get_currency_field_name
+from ._compat import get_fields
+from .models.fields import MoneyField
+from .utils import get_currency_field_name
 
 
 Serializer = JSONSerializer
@@ -30,8 +31,6 @@ def Deserializer(stream_or_string, **options):  # noqa
         stream_or_string = stream_or_string.decode('utf-8')
     try:
         for obj in json.loads(stream_or_string):
-            money_fields = {}
-            fields = {}
             try:
                 Model = _get_model(obj['model'])
             except DeserializationError:
@@ -39,10 +38,9 @@ def Deserializer(stream_or_string, **options):  # noqa
                     continue
                 else:
                     raise
-            try:
-                field_names = set(f.name for f in Model._meta.get_fields())
-            except AttributeError:
-                field_names = set(f.name for f in Model._meta.fields)
+            money_fields = {}
+            fields = {}
+            field_names = get_fields(Model)
             for (field_name, field_value) in six.iteritems(obj['fields']):
                 if ignore and field_name not in field_names:
                     # skip fields no longer on model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 import pytest
 from moneyed import Money
 
+from tests.testapp.models import InheritorModel, ModelWithDefaultAsInt
+
 from ._compat import patch
 
 
@@ -18,3 +20,15 @@ def patched_convert_money():
 
     with patch('djmoney.models.fields.convert_money', side_effect=convert_money) as patched:
         yield patched
+
+
+@pytest.fixture
+def m2m_object():
+    return ModelWithDefaultAsInt.objects.create(money=Money(100, 'USD'))
+
+
+@pytest.fixture
+def concrete_instance(m2m_object):
+    instance = InheritorModel.objects.create()
+    instance.m2m_field.add(m2m_object)
+    return instance

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,18 @@
+# coding: utf-8
+import pytest
+
+from djmoney.serializers import Deserializer, Serializer
+
+from .testapp.models import ModelWithDefaultAsInt
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_m2m_fields_are_not_lost(concrete_instance, m2m_object):
+    """
+    See #184.
+    """
+    value = Serializer().serialize([concrete_instance])
+    m2m_data = list(Deserializer(value, ignorenonexistent=True))[0].m2m_data
+    assert m2m_object in ModelWithDefaultAsInt.objects.filter(pk__in=m2m_data['m2m_field'])

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -75,6 +75,7 @@ class ModelWithNonMoneyField(models.Model):
 
 class AbstractModel(models.Model):
     money = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
+    m2m_field = models.ManyToManyField(ModelWithDefaultAsInt)
 
     class Meta:
         abstract = True


### PR DESCRIPTION
For me this bug cause errors in `generate_patch_html` inside django-reversion. I'll add some refactoring and tests for serializer in separate PR.

Best regards, Dmitry