### PR TITLE
Fix fields caching

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -373,6 +373,7 @@ class MoneyField(models.DecimalField):
                 choices=self.currency_choices
             )
             c_field.creation_counter = self.creation_counter
+            self.creation_counter += 1
             cls.add_to_class(c_field_name, c_field)
 
         super(MoneyField, self).contribute_to_class(cls, name)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -410,3 +410,15 @@ class TestDifferentCurrencies:
 def test_manager_instance_access(model_class):
     with pytest.raises(AttributeError):
         model_class().objects.all()
+
+
+@pytest.mark.skipif(VERSION >= (1, 10), reason='Django >= 1.10 dropped `get_field_by_name` method of `Options`.')
+def test_get_field_by_name():
+    assert BaseModel._meta.get_field_by_name('money')[0].__class__.__name__ == 'MoneyField'
+    assert BaseModel._meta.get_field_by_name('money_currency')[0].__class__.__name__ == 'CurrencyField'
+
+
+def test_different_hashes():
+    money = BaseModel._meta.get_field('money')
+    money_currency = BaseModel._meta.get_field('money_currency')
+    assert hash(money) != hash(money_currency)


### PR DESCRIPTION
In Django fields comparison is based on `creation_counter` attribute, so CurrencyField and MoneyField have the same creation_counter value. This leads to problems with caching in model options