### PR TITLE
Let MoneyPatched to be deconstructed in migrations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,21 @@ Searching for models with money fields:
         BankAccount.objects.filter(balance__gt=Money(1, USD))
         # Returns the "account" object
 
+Special note on serialized arguments: if your model definition 
+requires serializing an instance of ``Money``, you can use ``MoneyPatched``
+instead.
+
+.. code:: python
+
+        from django.core.validators import MinValueValidator
+        from django.db import models
+        from djmoney.models.fields import MoneyField, MoneyPatched
+
+        class BankAccount(models.Model):
+
+            balance = MoneyField(max_digits=10, decimal_places=2, validators=[MinValueValidator(MoneyPatched(100, 'GBP'))])
+
+
 If you use South to handle model migration, things will "Just Work" out
 of the box. South is an optional dependency and things will work fine
 without it.

--- a/djmoney/_compat.py
+++ b/djmoney/_compat.py
@@ -38,6 +38,13 @@ except NameError:
     string_types = (str, bytes)
 
 
+if VERSION >= (1, 7):
+    from django.utils.deconstruct import deconstructible
+else:
+    def deconstructible(cls):
+        return cls
+
+
 def split_expression(expr):
     """
     Returns lhs and rhs of the expression.

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -19,6 +19,7 @@ from djmoney import forms
 from .._compat import (
     BaseExpression,
     Expression,
+    deconstructible,
     smart_unicode,
     split_expression,
     string_types,
@@ -54,6 +55,7 @@ class NotSupportedLookup(Exception):
         return 'Lookup \'%s\' is not supported for MoneyField' % self.lookup
 
 
+@deconstructible
 class MoneyPatched(Money):
 
     # Set to True or False has a higher priority

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,6 +38,10 @@ from .testapp.models import (
 )
 
 
+if VERSION >= (1, 7):
+    from django.db.migrations.writer import MigrationWriter
+
+
 pytestmark = pytest.mark.django_db
 
 
@@ -422,3 +426,8 @@ def test_different_hashes():
     money = BaseModel._meta.get_field('money')
     money_currency = BaseModel._meta.get_field('money_currency')
     assert hash(money) != hash(money_currency)
+
+
+@pytest.mark.skipif(VERSION < (1, 7), reason='Django < 1.7 handles migrations differently')
+def test_migration_serialization():
+    MigrationWriter.serialize(MoneyPatched(100, 'GBP'))


### PR DESCRIPTION
In some situations, `Money` objects will need to be serialized in  migrations. My particular case was a field like
```
class MyModel(models.Model):
    amount = MoneyField(null=True, max_digits=9, decimal_places=2, validators=[MinValueValidator(Money(0, 'USD'))])
```

which triggered
```
ValueError: Cannot serialize: 0 USD
There are some values Django cannot serialize into migration files.
For more, see https://docs.djangoproject.com/en/1.9/topics/migrations/#migration-serializing
```

But with `@destructible` wrapping the class, will work on django > 1.7.