### PR TITLE
Patch potential problem to avoid overriding other managers in same model

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -463,7 +463,7 @@ def patch_managers(sender, **kwargs):
     if hasattr(sender._meta, 'has_money_field'):
         sender.copy_managers([
             (_id, name, money_manager(manager))
-            for _id, name, manager in sender._meta.concrete_managers
+            for _id, name, manager in sender._meta.concrete_managers if name == 'objects'
         ])
 
 


### PR DESCRIPTION
Current code has a potential problem when model uses two or more managers. This code overwrites every manager to ``MoneyManager``, which causes critical errors during migration.

e.g. If model has ``CurrentSiteManager`` as a field,
```
on_site = CurrentSiteManager()
```

``make migrations`` command generates the migration code to alter ``on_site`` manager from ``CurrentSiteManager`` to ``MoneyManager``.

This patch only overwrites model's ``objects``. Code will work as described in README.md. (default is ``objects``, and should use ``money_manager`` for other fields) 