### PR TITLE
Fixed to correctly display the default currency choice in a form

### DIFF
--- a/djmoney/forms/fields.py
+++ b/djmoney/forms/fields.py
@@ -35,6 +35,9 @@ class MoneyField(MultiValueField):
             warn('currency_choices will be deprecated in favor of choices', PendingDeprecationWarning)
             choices = currency_choices
 
+        # get the default currency if one was specified
+        default_currency = kwargs.pop('default_currency', None)
+
         amount_field = DecimalField(max_value, min_value, max_digits, decimal_places, *args, **kwargs)
         currency_field = ChoiceField(choices=choices)
 
@@ -53,6 +56,10 @@ class MoneyField(MultiValueField):
         # The two fields that this widget comprises
         fields = (amount_field, currency_field)
         super(MoneyField, self).__init__(fields, *args, **kwargs)
+
+        # set the initial value to the default currency so that the
+        # default currency appears as the selected menu item
+        self.initial = [None, default_currency]
 
     def compress(self, data_list):
         if data_list:

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -399,6 +399,7 @@ class MoneyField(models.DecimalField):
         defaults = {'form_class': forms.MoneyField}
         defaults.update(kwargs)
         defaults['currency_choices'] = self.currency_choices
+        defaults['default_currency'] = self.default_currency
         return super(MoneyField, self).formfield(**defaults)
 
     def get_south_default(self):

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if sys.version_info[:2] == (3, 2):
 
 setup(
     name='django-money',
-    version='0.9',
+    version='0.8.1',
     description='Adds support for using money and currency fields in django models and forms. '
                 'Uses py-moneyed as the money implementation.',
     url='https://github.com/django-money/django-money',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if sys.version_info[:2] == (3, 2):
 
 setup(
     name='django-money',
-    version='0.8',
+    version='0.9',
     description='Adds support for using money and currency fields in django models and forms. '
                 'Uses py-moneyed as the money implementation.',
     url='https://github.com/django-money/django-money',


### PR DESCRIPTION
Updated so that if a default currency is specified for a field in the model, it will be the selected choice when that field is shown in a form (either a user form or the Django admin)