### PR TITLE
Refactoring of a way of running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     django{16,15}-py{33,32,27,26,py,py3}
     django14-py{27,26,py}
     lint
+skipsdist = true
 
 [testenv]
 deps =
@@ -17,14 +18,14 @@ deps =
     django19: {[django]1.9.x}
     django110: {[django]1.10.x}
     django_master: {[django]master}
+    py26,py27,py32,pypy: mock
     py32: coverage==3.7.1
     pytest<3.0.0
     pytest-django<3.0.0
     pytest-cov
     django-money-rates
-commands = make test
+commands = {posargs:py.test --ds=tests.settings --cov=./djmoney tests}
 usedevelop = true
-whitelist_externals = make
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Hi!
What do you think about such approach?
It speeds up tests in about 20% on my machine, also there is no need to specify tests dependencies in 2 places - now only in tox.ini.
Another thing - it allows us to implement admin viewer for development without adding `tests` module to packages in `setup.py` (#217)