### PR TITLE
Re-add PyPI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,10 @@ Django-money
    :target: http://django-money.readthedocs.io/en/latest/
    :alt: Documentation Status
 
+.. image:: https://img.shields.io/pypi/v/django-money.svg
+   :target: https://pypi.python.org/pypi/django-money
+   :alt: PyPI
+
 A little Django app that uses ``py-moneyed`` to add support for Money
 fields in your models and forms.
 


### PR DESCRIPTION
Removed as fury.io wasn’t playing nice with Sphinx (I suspect it’s because there is a HTTP redirect involved).

Just discovered that shield.io is fine, so adding the badge back with that.