### PR TITLE
Rules for uploading a release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,11 @@ coverage:
 
 install: clean
 	python setup.py install
+
+release: dist  ## Generate and upload release to PyPi
+	twine upload -s dist/*
+
+dist: clean  ## Generate source dist and wheels
+	python setup.py bdist_wheel
+	ls -l dist
+


### PR DESCRIPTION
@Stranger6667 if you use `make release` for future releases, it will invoke `twine` etc. to upload it.

We could potentially add `git tag -s`, but for my own usecase, I have to tell `git tag` which PGP key to use, so it would fail for me, which is why I'm not using it. It's a manual thing to remember, as with creating the release entry on Github.