### PR TITLE
Formfield doesn't use model field's default amount

### DIFF
--- a/djmoney/forms/fields.py
+++ b/djmoney/forms/fields.py
@@ -25,7 +25,8 @@ class MoneyField(MultiValueField):
 
     def __init__(self, currency_widget=None, currency_choices=CURRENCY_CHOICES,
                  choices=CURRENCY_CHOICES, max_value=None, min_value=None,
-                 max_digits=None, decimal_places=None, *args, **kwargs):
+                 max_digits=None, decimal_places=None, default_amount=None,
+                 *args, **kwargs):
 
         # choices does not make sense in this context, it would mean we had
         # to replace two widgets with one widget dynamically... which is a
@@ -62,7 +63,7 @@ class MoneyField(MultiValueField):
 
         # set the initial value to the default currency so that the
         # default currency appears as the selected menu item
-        self.initial = [None, default_currency]
+        self.initial = [default_amount, default_currency]
 
     def compress(self, data_list):
         if data_list:

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -411,6 +411,8 @@ class MoneyField(models.DecimalField):
         defaults.update(kwargs)
         defaults['currency_choices'] = self.currency_choices
         defaults['default_currency'] = self.default_currency
+        if self.default is not None:
+            defaults['default_amount'] = self.default.amount
         return super(MoneyField, self).formfield(**defaults)
 
     def value_to_string(self, obj):

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -14,6 +14,7 @@ import moneyed
 from moneyed import Money
 
 from .testapp.forms import (
+    DefaultMoneyModelForm,
     MoneyForm,
     MoneyFormMultipleCurrencies,
     MoneyModelForm,
@@ -111,3 +112,12 @@ def test_default_currency():
     else:
         expected = '<option value="USD" selected="selected">US Dollar</option>'
     assert expected in form.as_p()
+
+
+def test_fields_default_amount_becomes_forms_initial():
+    """
+    Formfield should take field's default amount
+    and put it in form field's initial value
+    """
+    form = DefaultMoneyModelForm()
+    assert form.fields['money'].initial == [123, 'PLN']

--- a/tests/testapp/forms.py
+++ b/tests/testapp/forms.py
@@ -10,7 +10,11 @@ from django import forms
 
 from djmoney.forms import MoneyField
 
-from .models import ModelWithVanillaMoneyField, NullMoneyFieldModel
+from .models import (
+    ModelWithDefaultAsString,
+    ModelWithVanillaMoneyField,
+    NullMoneyFieldModel,
+)
 
 
 class MoneyForm(forms.Form):
@@ -37,3 +41,10 @@ class NullableModelForm(forms.ModelForm):
     class Meta:
         model = NullMoneyFieldModel
         fields = ('field', )
+
+
+class DefaultMoneyModelForm(forms.ModelForm):
+
+    class Meta:
+        model = ModelWithDefaultAsString
+        fields = ('money', )


### PR DESCRIPTION
If you have model field with some `default`, then this amount should be set as initial for field in form