### PR TITLE
Added ability to configure decimal places output

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -27,7 +27,7 @@ from .._compat import (
     split_expression,
     string_types,
 )
-from ..settings import CURRENCY_CHOICES, DEFAULT_CURRENCY
+from ..settings import CURRENCY_CHOICES, DECIMAL_PLACES, DEFAULT_CURRENCY
 from ..utils import get_currency_field_name, prepare_expression
 
 
@@ -139,9 +139,9 @@ class MoneyPatched(Money):
         if self.__use_l10n():
             locale = self.__get_current_locale()
             if locale:
-                return format_money(self, locale=locale)
+                return format_money(self, locale=locale, decimal_places=DECIMAL_PLACES)
 
-        return format_money(self)
+        return format_money(self, decimal_places=DECIMAL_PLACES)
 
     __str__ = __unicode__
 

--- a/djmoney/settings.py
+++ b/djmoney/settings.py
@@ -22,3 +22,4 @@ else:
                         c.code != DEFAULT_CURRENCY_CODE]
 
 CURRENCY_CHOICES.sort(key=operator.itemgetter(1, 0))
+DECIMAL_PLACES = getattr(settings, 'CURRENCY_DECIMAL_PLACES', 2)


### PR DESCRIPTION
Tests in django master branch are failed because they changed the logic of rendering Select widget.

I decided create pull request in django project to remove '\n' character in select options which is comes from template rendering.
See details here:
https://github.com/django/django/pull/7769

I hope this request will be approved and then django-money tests will be passed.
Otherwise we should fix the test.

Thank you.