### PR TITLE
The default amount should be set via `defaults`

### DIFF
--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -144,11 +144,12 @@ def _expand_money_kwargs(model, args=(), kwargs=None, exclusions=()):
                 if is_in_lookup(name, value):
                     args += (_convert_in_lookup(model, name, value), )
                     del kwargs[name]
-            elif isinstance(field, CurrencyField):
+            elif isinstance(field, CurrencyField) and 'defaults' in exclusions:
                 money_field_name = name[:-9]  # Remove '_currency'
                 if money_field_name not in involved_fields:
                     money_field = _get_field(model, money_field_name)
-                    kwargs[money_field_name] = money_field.default.amount
+                    kwargs['defaults'] = kwargs.get('defaults', {})
+                    kwargs['defaults'][money_field_name] = money_field.default.amount
 
     return args, kwargs
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,6 +37,7 @@ from .testapp.models import (
     ModelWithDefaultAsStringWithCurrency,
     ModelWithNonMoneyField,
     ModelWithTwoMoneyFields,
+    ModelWithUniqueIdAndCurrency,
     ModelWithVanillaMoneyField,
     NullMoneyFieldModel,
     ProxyModel,
@@ -238,6 +239,14 @@ class TestGetOrCreate:
     def test_get_or_create_respects_currency(self, kwargs, currency):
         instance, created = ModelWithVanillaMoneyField.objects.get_or_create(**kwargs)
         assert str(instance.money.currency) == currency, 'currency should be taken into account in get_or_create'
+
+    def test_get_or_create_respects_defaults(self):
+        instance = ModelWithUniqueIdAndCurrency.objects.create(money=Money(0, 'SEK'))
+        _, created = ModelWithUniqueIdAndCurrency.objects.get_or_create(
+            id=instance.id,
+            money_currency=instance.money_currency
+        )
+        assert not created
 
     def test_defaults(self):
         money = Money(10, 'EUR')

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -27,6 +27,13 @@ class ModelWithDefaultAsInt(models.Model):
     money = MoneyField(default=123, max_digits=10, decimal_places=2, default_currency='GHS')
 
 
+class ModelWithUniqueIdAndCurrency(models.Model):
+    money = MoneyField(default=123, max_digits=10, decimal_places=2, default_currency='GHS')
+
+    class Meta:
+        unique_together = ('id', 'money')
+
+
 class ModelWithDefaultAsStringWithCurrency(models.Model):
     money = MoneyField(default='123 USD', max_digits=10, decimal_places=2)
 


### PR DESCRIPTION
I've noticed a regression in the codebase, introduced in #227 (a09a2d43bac9f3d3db85a09bd6b19f946a86a880 to be exact). It broke the following use case of mine:

```python
class Wallet(UUIDModel):
    owner_id = models.UUIDField()
    balance = MoneyField(
        default=Money(0, settings.DEFAULT_CURRENCY),
        max_digits=10,
        decimal_places=2,
        default_currency=settings.DEFAULT_CURRENCY
    )

    class Meta:
        unique_together = ('owner_id', 'balance_currency',)
```

Every user can own multiple wallets with different currencies, thus the UNIQUE index on both `owner_id` and `balance_currency`. 


The problem lies in the changes to the behaviour of `_expand_money_kwargs`. They made following code snippet...

```python
>>> instance = ModelWithUniqueIdAndCurrency.objects.create(money=Money(0, 'SEK'))
>>> Wallet.objects.get_or_create(owner_id=instance.id, balance_currency='SEK')
```

...produce following query and error:
```self = <django.db.backends.sqlite3.base.SQLiteCursorWrapper object at 0x104071d38>
query = 'INSERT INTO "testapp_modelwithuniqueidandcurrency" ("id", "money_currency", "money") SELECT ?, ?, ?', params = (1, 'SEK', '123.00')

    def execute(self, query, params=None):
        if params is None:
            return Database.Cursor.execute(self, query)
        query = self.convert_query(query)
>       return Database.Cursor.execute(self, query, params)
E       django.db.utils.IntegrityError: UNIQUE constraint failed: testapp_modelwithuniqueidandcurrency.id
```

`_expand_money_kwargs` set the value of `money` to the default value of the field, which should not be the correct behaviour.

This pull requests fixes the issues with all the tests passing. It is however a quickfix and feels a bit hacky. I feel also like `_expand_money_kwargs` is a bit messy and there may be more bugs hiding in there. You are welcome to review the change and suggest improvements! 🙌🏻