### PR TITLE
Issue #292: Fix POST/PUT/PATCH in django rest framework. 

### DIFF
--- a/djmoney/contrib/django_rest_framework/fields.py
+++ b/djmoney/contrib/django_rest_framework/fields.py
@@ -14,7 +14,7 @@ class MoneyField(DecimalField):
     """
 
     def get_value(self, data):
-        amount = super().get_value(data)
+        amount = super(MoneyField, self).get_value(data)
         currency = data.get('{}_currency'.format(self.field_name), None)
         if currency:
             return Money(amount, currency)

--- a/djmoney/contrib/django_rest_framework/fields.py
+++ b/djmoney/contrib/django_rest_framework/fields.py
@@ -13,6 +13,13 @@ class MoneyField(DecimalField):
     does decimal's validation during transformation to native value.
     """
 
+    def get_value(self, data):
+        amount = super().get_value(data)
+        currency = data.get('{}_currency'.format(self.field_name), None)
+        if currency:
+            return Money(amount, currency)
+        return amount
+
     if IS_DRF_3:
 
         def to_representation(self, obj):

--- a/djmoney/contrib/django_rest_framework/fields.py
+++ b/djmoney/contrib/django_rest_framework/fields.py
@@ -2,6 +2,7 @@
 from rest_framework.serializers import DecimalField, ModelSerializer
 
 from djmoney.models.fields import MoneyField as ModelField
+from djmoney.utils import get_currency_field_name
 from moneyed import Money
 
 from .helpers import IS_DRF_3
@@ -26,7 +27,7 @@ class MoneyField(DecimalField):
 
         def get_value(self, data):
             amount = super(MoneyField, self).get_value(data)
-            currency = data.get('{}_currency'.format(self.field_name), None)
+            currency = data.get(get_currency_field_name(self.field_name), None)
             if currency:
                 return Money(amount, currency)
             return amount
@@ -49,7 +50,7 @@ class MoneyField(DecimalField):
 
         def field_from_native(self, data, files, field_name, into):
             super(MoneyField, self).field_from_native(data, files, field_name, into)
-            currency = data.get('{}_currency'.format(field_name), None)
+            currency = data.get(get_currency_field_name(field_name), None)
             if currency:
                 into[field_name] = Money(into[field_name], currency)
 

--- a/djmoney/contrib/django_rest_framework/fields.py
+++ b/djmoney/contrib/django_rest_framework/fields.py
@@ -13,14 +13,7 @@ class MoneyField(DecimalField):
     does decimal's validation during transformation to native value.
     """
 
-    def get_value(self, data):
-        amount = super(MoneyField, self).get_value(data)
-        currency = data.get('{}_currency'.format(self.field_name), None)
-        if currency:
-            return Money(amount, currency)
-        return amount
-
-    if IS_DRF_3:
+    if IS_DRF_3:  # noqa
 
         def to_representation(self, obj):
             return super(MoneyField, self).to_representation(obj.amount)
@@ -30,6 +23,13 @@ class MoneyField(DecimalField):
                 amount = super(MoneyField, self).to_internal_value(data.amount)
                 return Money(amount, data.currency)
             return super(MoneyField, self).to_internal_value(data)
+
+        def get_value(self, data):
+            amount = super(MoneyField, self).get_value(data)
+            currency = data.get('{}_currency'.format(self.field_name), None)
+            if currency:
+                return Money(amount, currency)
+            return amount
 
     else:
 
@@ -46,6 +46,12 @@ class MoneyField(DecimalField):
         def validate(self, value):
             amount = value.amount if isinstance(value, Money) else value
             return super(MoneyField, self).validate(amount)
+
+        def field_from_native(self, data, files, field_name, into):
+            super(MoneyField, self).field_from_native(data, files, field_name, into)
+            currency = data.get('{}_currency'.format(field_name), None)
+            if currency:
+                into[field_name] = Money(into[field_name], currency)
 
 
 def register_money_field():

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -92,4 +92,7 @@ class TestMoneyField:
     def test_post_put_values(self, body, expected):
         serializer = self.get_serializer(NullMoneyFieldModel, data=body)
         serializer.is_valid()
-        assert serializer.validated_data['field'] == expected
+        if IS_DRF_3:
+            assert serializer.validated_data['field'] == expected
+        else:
+            assert Money(serializer.data['field'], serializer.data['field_currency']) == expected

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -81,3 +81,15 @@ class TestMoneyField:
         assert not serializer.is_valid()
         error_text = 'This field may not be null.' if IS_DRF_3 else 'This field is required.'
         assert serializer.errors == {'money': [error_text]}
+
+    @pytest.mark.parametrize(
+        'body, expected', (
+            ({'field': '10', 'field_currency': 'EUR'}, Money(10, 'EUR')),
+            ({'field': '12.20', 'field_currency': 'GBP'}, Money(12.20, 'GBP')),
+            ({'field': '15.15', 'field_currency': 'USD'}, Money(15.15, 'USD')),
+        ),
+    )
+    def test_post_put_values(self, body, expected):
+        serializer = self.get_serializer(NullMoneyFieldModel, data=body)
+        serializer.is_valid()
+        assert serializer.validated_data['field'] == expected


### PR DESCRIPTION
The currency value is ignored. Therefore, the default currency is always saved and used.
Implementing the `get_value` method in MoneyField class fix the problem.