### PR TITLE
0.11.x into master

### DIFF
--- a/djmoney/__init__.py
+++ b/djmoney/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.11'
+__version__ = '0.11.1'
 default_app_config = 'djmoney.apps.MoneyConfig'

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -219,7 +219,7 @@ class MoneyFieldProxy(object):
 
     def __get__(self, obj, type=None):
         if obj is None:
-            raise AttributeError('Can only be accessed via an instance.')
+            return self
         data = obj.__dict__
         if isinstance(data[self.field.name], BaseExpression):
             return data[self.field.name]

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,11 @@
 Changelog
 =========
 
+Changes in 0.11.1
+-----------------
+
+- Fixed access to models properties `#297`_ (`mithrilstar`_, `Stranger6667`_)
+
 Changes in 0.11
 ---------------
 
@@ -201,6 +206,7 @@ Changes in 0.3
 - South support: Declare default attribute values. (`pjdelport`_)
 
 
+.. _#297: https://github.com/django-money/django-money/issues/297
 .. _#292: https://github.com/django-money/django-money/issues/292
 .. _#278: https://github.com/django-money/django-money/issues/278
 .. _#277: https://github.com/django-money/django-money/issues/277
@@ -276,6 +282,7 @@ Changes in 0.3
 .. _k8n: https://github.com/k8n
 .. _lobziik: https://github.com/lobziik
 .. _mattions: https://github.com/mattions
+.. _mithrilstar: https://github.com/mithrilstar
 .. _msgre: https://github.com/msgre
 .. _mstarostik: https://github.com/mstarostik
 .. _pjdelport: https://github.com/pjdelport

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -642,3 +642,9 @@ def test_override_decorator():
     """
     with override('cs'):
         assert str(MoneyPatched(10, 'CZK')) == 'Kč10.00'
+
+
+def test_properties_access():
+    with pytest.raises(TypeError) as exc:
+        ModelWithVanillaMoneyField(money=Money(1, 'USD'), bla=1)
+    assert str(exc.value) == "'bla' is an invalid keyword argument for this function"


### PR DESCRIPTION
Firstly, a clarification that I just released the current `master` branch as `0.11.2` - I see nothing in the log after 9e74fd0dd7297c37738810fe6ff3cc1deee143f9 that hints it had `0.12dev` changes... so it should be without problems. This wasn't really a deliberate action, but I did some changes in `master` when you landed `0.11.1` in `0.11.x` and now the `0.11.2` PR bug fix went into `master` instead of `0.11.x` :)

I know the `0.11.x` branch is needed as soon as `master` diverges from the `0.11` release series, so I didn't delete it (but maybe we should).

Here's what I did:

1. I rebased the current master onto `0.11.x` and force-pushed so it's consistent with `master`.
2. Then I merged `0.11.x` into master and made this PR

I can live with having a branch for supporting the `0.11.x` series, but I have two arguments to back up a branch strategy where `0.11.x` only gets created once needed:

1. To wait with `0.11.x` until something is merged that *cannot* be released in 0.11 and is so unstable that we can't release `0.12` (thus making the `master` branch unreleasable).
2. To wait with `0.11.x` until a patch arrives for an issue that has to be backported and then branch of the latest 0.11 tag (currently `0.11.2`).

Also, I think it's cool to skip backporting fixes to 0.11 series... I mean, that's more because I prefer having proper backwards support in new releases so everyone can always enjoy the latest release of an app :)