### PR TITLE
Restored support for Django < 1.8 & Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,28 @@ env:
   - TOX_ENV=django18-py32
   - TOX_ENV=django18-py27
   - TOX_ENV=django18-pypy
+  - TOX_ENV=django17-py34
+  - TOX_ENV=django17-py33
+  - TOX_ENV=django17-py32
+  - TOX_ENV=django17-py27
+  - TOX_ENV=django17-pypy
+  - TOX_ENV=django16-py33
+  - TOX_ENV=django16-py32
+  - TOX_ENV=django16-py27
+  - TOX_ENV=django16-pypy
+  - TOX_ENV=django15-py27
+  - TOX_ENV=django15-py33
+  - TOX_ENV=django15-py32
+  - TOX_ENV=django15-pypy
+  - TOX_ENV=django14-py27
+  - TOX_ENV=django14-pypy
+matrix:
+  include:
+  - python: "2.6"
+    env: TOX_ENV=django16-py26
+  - python: "2.6"
+    env: TOX_ENV=django15-py26
+  - python: "2.6"
+    env: TOX_ENV=django14-py26
 after_success:
   - codecov

--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,9 @@ http://code.google.com/p/python-money/
 
 This version adds tests, and comes with several critical bugfixes.
 
-Django versions supported: 1.8, 1.9, 1.10, 1.11
+Django versions supported: 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11
 
-Python versions supported: 2.7, 3.2, 3.3, 3.4, 3.5, 3.6
+Python versions supported: 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6
 
 PyPy versions supported: PyPy 2.6, PyPy3 2.4
 
@@ -101,6 +101,10 @@ instead.
         class BankAccount(models.Model):
             balance = MoneyField(max_digits=10, decimal_places=2, validators=[MinValueValidator(MoneyPatched(100, 'GBP'))])
 
+
+If you use South to handle model migration, things will "Just Work" out
+of the box. South is an optional dependency and things will work fine
+without it.
 
 Adding a new Currency
 ---------------------
@@ -254,6 +258,23 @@ Formatting the number with currency:
 
         MoneyPatched object
 
+Admin integration
+-----------------
+
+For Django **1.7+** integration works automatically if ``djmoney`` is in the ``INSTALLED_APPS``.
+
+For older versions you should use the following code:
+
+.. code:: python
+
+    from djmoney.admin import setup_admin_integration
+    
+    # NOTE. Only for Django < 1.7
+    setup_admin_integration()
+
+
+There is no single opinion about where to place on-start-up code in Django < 1.7, but we'd recommend to place it
+in the top-level `urls.py`.
 
 Testing
 -------
@@ -298,8 +319,19 @@ conversions happening in different directions.
 Usage with Django REST Framework
 --------------------------------
 
-Make sure that ``djmoney`` is in the ``INSTALLED_APPS`` of your ``settings.py`` and MoneyFields to automatically
-work with Django REST Framework.
+In Django **1.7+**, for MoneyFields to automatically work with Django REST Framework, make sure
+that ``djmoney`` is in the ``INSTALLED_APPS`` of your ``settings.py``.
+
+For older versions you should use the following code:
+
+.. code:: python
+
+    from djmoney.contrib.django_rest_framework import register_money_field
+ 
+    # NOTE. Only for Django < 1.7
+    register_money_field()
+
+Just put it in the end of your root ``urls.py`` file.
 
 Built-in serializer works in the following way:
 

--- a/djmoney/_compat.py
+++ b/djmoney/_compat.py
@@ -1,8 +1,33 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
+import functools
+
 from django import VERSION
 from django.db.models.manager import ManagerDescriptor
 
+
+try:
+    import django.contrib.admin.utils as admin_utils
+except ImportError:
+    # Django < 1.5
+    import django.contrib.admin.util as admin_utils
+
+try:
+    from django.db.models.constants import LOOKUP_SEP
+except ImportError:
+    # Django < 1.5
+    LOOKUP_SEP = '__'
+
+try:
+    from django.db.models.expressions import BaseExpression
+except ImportError:
+    # Django < 1.8
+    from django.db.models.expressions import ExpressionNode as BaseExpression
+
+try:
+    from django.contrib.admin.utils import lookup_field
+except ImportError:
+    from django.contrib.admin.util import lookup_field
 
 try:
     from django.utils.encoding import smart_unicode
@@ -10,6 +35,23 @@ except ImportError:
     # Python 3
     from django.utils.encoding import smart_text as smart_unicode
 
+try:
+    from django.db.models import Case, Func, Value, When
+except ImportError:
+    Case, Func, Value, When = None, None, None, None
+
+try:
+    from django.utils.six import wraps
+except ImportError:
+    # Django 1.5, and some versions from 1.4.x branch
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS, updated=functools.WRAPPER_UPDATES):
+
+        def wrapper(f):
+            f = functools.wraps(wrapped)(f)
+            f.__wrapped__ = wrapped
+            return f
+
+        return wrapper
 
 try:
     string_types = (basestring,)
@@ -28,6 +70,63 @@ except NameError:
     except ImportError:
         # Python 3.2 & 3.3
         from imp import reload as reload_module
+
+if VERSION >= (1, 7):
+    from django.utils.deconstruct import deconstructible
+else:
+    def deconstructible(cls):
+        return cls
+
+
+def split_expression(expr):
+    """
+    Returns lhs and rhs of the expression.
+    """
+    if VERSION < (1, 8):
+        return expr.children
+    else:
+        return expr.lhs, expr.rhs
+
+
+def set_expression_rhs(expr, value):
+    """
+    Sets right hand side value of the expression.
+    """
+    if VERSION < (1, 8):
+        expr.children[1] = value
+    else:
+        expr.rhs.value = value
+
+
+def get_field_names(model):
+    """
+    Returns a set of field names associated with the model.
+    """
+    opts = model._meta
+    if VERSION < (1, 8):
+        return opts.get_all_field_names()
+    else:
+        return set(field.name for field in opts.get_fields())
+
+
+def get_fields(model):
+    """
+    Returns a set of field instances associated with the model.
+    """
+    opts = model._meta
+    if VERSION < (1, 8):
+        return opts.fields
+    else:
+        return opts.get_fields()
+
+
+def resolve_field(qs, parts, opts, alias):
+    if VERSION < (1, 6):
+        return qs.setup_joins(parts, opts, alias, False)[0]
+    elif VERSION[:2] == (1, 6):
+        return qs.names_to_path(parts, opts, True, True)[1]
+    else:
+        return qs.names_to_path(parts, opts, True, fail_on_missing=False)[1]
 
 
 def setup_managers(sender):

--- a/djmoney/admin.py
+++ b/djmoney/admin.py
@@ -1,15 +1,14 @@
 # coding: utf-8
-import django.contrib.admin.utils as admin_utils
 from django import VERSION
 
-from ._compat import text_type
+from ._compat import admin_utils, text_type
 from .models.fields import MoneyField
 
 
 def setup_admin_integration():
     original_display_for_field = admin_utils.display_for_field
 
-    if VERSION[:2] == (1, 8):
+    if VERSION < (1, 9):
 
         def display_for_field(value, field):
             if isinstance(field, MoneyField):

--- a/djmoney/contrib/django_rest_framework/__init__.py
+++ b/djmoney/contrib/django_rest_framework/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from .fields import MoneyField, register_money_field  # noqa
+from .helpers import VERSION  # noqa

--- a/djmoney/contrib/django_rest_framework/fields.py
+++ b/djmoney/contrib/django_rest_framework/fields.py
@@ -5,6 +5,8 @@ from djmoney.models.fields import MoneyField as ModelField
 from djmoney.utils import get_currency_field_name
 from moneyed import Money
 
+from .helpers import IS_DRF_3
+
 
 class MoneyField(DecimalField):
     """
@@ -12,22 +14,47 @@ class MoneyField(DecimalField):
     does decimal's validation during transformation to native value.
     """
 
-    def to_representation(self, obj):
-        return super(MoneyField, self).to_representation(obj.amount)
+    if IS_DRF_3:  # noqa
 
-    def to_internal_value(self, data):
-        if isinstance(data, Money):
-            amount = super(MoneyField, self).to_internal_value(data.amount)
-            return Money(amount, data.currency)
-        return super(MoneyField, self).to_internal_value(data)
+        def to_representation(self, obj):
+            return super(MoneyField, self).to_representation(obj.amount)
 
-    def get_value(self, data):
-        amount = super(MoneyField, self).get_value(data)
-        currency = data.get(get_currency_field_name(self.field_name), None)
-        if currency:
-            return Money(amount, currency)
-        return amount
+        def to_internal_value(self, data):
+            if isinstance(data, Money):
+                amount = super(MoneyField, self).to_internal_value(data.amount)
+                return Money(amount, data.currency)
+            return super(MoneyField, self).to_internal_value(data)
+
+        def get_value(self, data):
+            amount = super(MoneyField, self).get_value(data)
+            currency = data.get(get_currency_field_name(self.field_name), None)
+            if currency:
+                return Money(amount, currency)
+            return amount
+
+    else:
+
+        def to_native(self, value):
+            amount = value.amount if isinstance(value, Money) else value
+            return super(MoneyField, self).to_native(amount)
+
+        def from_native(self, value):
+            if isinstance(value, Money):
+                amount = super(MoneyField, self).from_native(value.amount)
+                return Money(amount, value.currency)
+            return super(MoneyField, self).from_native(value)
+
+        def validate(self, value):
+            amount = value.amount if isinstance(value, Money) else value
+            return super(MoneyField, self).validate(amount)
+
+        def field_from_native(self, data, files, field_name, into):
+            super(MoneyField, self).field_from_native(data, files, field_name, into)
+            currency = data.get(get_currency_field_name(field_name), None)
+            if currency:
+                into[field_name] = Money(into[field_name], currency)
 
 
 def register_money_field():
-    ModelSerializer.serializer_field_mapping[ModelField] = MoneyField
+    mapping = ModelSerializer.serializer_field_mapping if IS_DRF_3 else ModelSerializer.field_mapping
+    mapping[ModelField] = MoneyField

--- a/djmoney/contrib/django_rest_framework/helpers.py
+++ b/djmoney/contrib/django_rest_framework/helpers.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from rest_framework import VERSION
+
+
+VERSION = [int(i) for i in VERSION.split('.')]
+
+IS_DRF_3 = VERSION >= [3, 0, 0]

--- a/djmoney/forms/fields.py
+++ b/djmoney/forms/fields.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 from warnings import warn
 
+from django import VERSION
+from django.core import validators
 from django.core.exceptions import ValidationError
 from django.forms import ChoiceField, DecimalField, MultiValueField
 
@@ -16,6 +18,10 @@ __all__ = ('MoneyField',)
 
 
 class MoneyField(MultiValueField):
+
+    # Django 1.5 compat:
+    if not hasattr(MultiValueField, 'empty_values'):
+        empty_values = list(validators.EMPTY_VALUES)
 
     def __init__(self, currency_widget=None, currency_choices=CURRENCY_CHOICES,
                  choices=CURRENCY_CHOICES, max_value=None, min_value=None,
@@ -35,6 +41,10 @@ class MoneyField(MultiValueField):
 
         amount_field = DecimalField(max_value, min_value, max_digits, decimal_places, *args, **kwargs)
         currency_field = ChoiceField(choices=choices)
+
+        if VERSION < (1, 8) and hasattr(amount_field, '_has_changed') and hasattr(currency_field, '_has_changed'):
+            amount_field.has_changed = amount_field._has_changed
+            currency_field.has_changed = currency_field._has_changed
 
         # TODO: No idea what currency_widget is supposed to do since it doesn't
         # even receive currency choices as input. Somehow it's supposed to be
@@ -65,7 +75,7 @@ class MoneyField(MultiValueField):
 
     def has_changed(self, initial, data):  # noqa
         if initial is None:
-            initial = ['' for _ in range(0, len(data))]
+            initial = ['' for x in range(0, len(data))]
         else:
             if not isinstance(initial, list):
                 initial = self.widget.decompress(initial)
@@ -106,3 +116,6 @@ class MoneyField(MultiValueField):
             return True
 
         return False
+
+    if VERSION < (1, 8):
+        _has_changed = has_changed

--- a/djmoney/forms/widgets.py
+++ b/djmoney/forms/widgets.py
@@ -21,3 +21,37 @@ class MoneyWidget(MultiWidget):
         if value is not None:
             return [value.amount, value.currency]
         return [None, self.default_currency]
+
+    # Needed for Django 1.5.x, where Field doesn't have the '_has_changed' method.
+    # But it mustn't run on Django 1.6, where it doesn't work and isn't needed.
+
+    if hasattr(TextInput, '_has_changed'):  # noqa
+        # This is a reimplementation of the MoneyField.has_changed,
+        # but for the widget.
+        def _has_changed(self, initial, data):
+            if initial is None:
+                initial = ['' for x in range(0, len(data))]
+            else:
+                if not isinstance(initial, list):
+                    initial = self.decompress(initial)
+
+            amount_widget, currency_widget = self.widgets
+            amount_initial, currency_initial = initial
+
+            try:
+                amount_data = data[0]
+            except IndexError:
+                amount_data = None
+
+            if amount_widget._has_changed(amount_initial, amount_data):
+                return True
+
+            try:
+                currency_data = data[1]
+            except IndexError:
+                currency_data = None
+
+            if currency_widget._has_changed(currency_initial, currency_data) and amount_data:
+                return True
+
+            return False

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -1,23 +1,31 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 
+import inspect
 from decimal import ROUND_DOWN, Decimal
 
 from django import VERSION
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
-from django.db.models import F, Field, Func, Value
-from django.db.models.expressions import BaseExpression
+from django.db.models import F, Field
 from django.db.models.signals import class_prepared
 from django.utils import translation
-from django.utils.deconstruct import deconstructible
 
 from djmoney import forms
 from moneyed import Currency, Money
 from moneyed.localization import _FORMATTER, format_money
 
-from .._compat import setup_managers, smart_unicode, string_types
+from .._compat import (
+    BaseExpression,
+    Func,
+    Value,
+    deconstructible,
+    setup_managers,
+    smart_unicode,
+    split_expression,
+    string_types,
+)
 from ..settings import CURRENCY_CHOICES, DECIMAL_PLACES, DEFAULT_CURRENCY
 from ..utils import get_currency_field_name, prepare_expression
 
@@ -144,7 +152,7 @@ def get_value(obj, expr):
     """
     if isinstance(expr, F):
         expr = getattr(obj, expr.name)
-    else:
+    elif hasattr(expr, 'value'):
         expr = expr.value
     return expr
 
@@ -157,9 +165,10 @@ def validate_money_expression(obj, expr):
       - Any operations with money in different currencies
       - Multiplication, division, modulo with money instances on both sides of expression
     """
+    lhs, rhs = split_expression(expr)
     connector = expr.connector
-    lhs = get_value(obj, expr.lhs)
-    rhs = get_value(obj, expr.rhs)
+    lhs = get_value(obj, lhs)
+    rhs = get_value(obj, rhs)
 
     if (not isinstance(rhs, Money) and connector in ('+', '-')) or connector == '^':
         raise ValidationError('Invalid F expression for MoneyField.', code='invalid')
@@ -220,9 +229,11 @@ class MoneyFieldProxy(object):
 
     def __set__(self, obj, value):  # noqa
         if isinstance(value, BaseExpression):
-            if isinstance(value, Value):
+            if Value and isinstance(value, Value):
                 value = self.prepare_value(obj, value.value)
-            elif not isinstance(value, Func):
+            elif Func and isinstance(value, Func):
+                pass
+            else:
                 validate_money_expression(obj, value)
                 prepare_expression(value)
         else:
@@ -258,15 +269,18 @@ class MoneyFieldProxy(object):
 class CurrencyField(models.CharField):
     description = 'A field which stores currency.'
 
-    def __init__(self, price_field=None, verbose_name=None, name=None, default=DEFAULT_CURRENCY, **kwargs):
+    def __init__(self, price_field=None, verbose_name=None, name=None,
+                 default=DEFAULT_CURRENCY, **kwargs):
         if isinstance(default, Currency):
             default = default.code
         kwargs['max_length'] = 3
         self.price_field = price_field
-        super(CurrencyField, self).__init__(verbose_name, name, default=default, **kwargs)
+        self.frozen_by_south = kwargs.pop('frozen_by_south', False)
+        super(CurrencyField, self).__init__(verbose_name, name, default=default,
+                                            **kwargs)
 
     def contribute_to_class(self, cls, name):
-        if name not in [f.name for f in cls._meta.fields]:
+        if not self.frozen_by_south and name not in [f.name for f in cls._meta.fields]:
             super(CurrencyField, self).contribute_to_class(cls, name)
 
 
@@ -283,8 +297,12 @@ class MoneyField(models.DecimalField):
         if not default_currency:
             default_currency = default.currency
 
+        if VERSION < (1, 7):
+            self.check_field_attributes(decimal_places, max_digits)
+
         self.default_currency = default_currency
         self.currency_choices = currency_choices
+        self.frozen_by_south = kwargs.pop('frozen_by_south', False)
 
         super(MoneyField, self).__init__(verbose_name, name, max_digits, decimal_places, default=default, **kwargs)
         self.creation_counter += 1
@@ -312,6 +330,16 @@ class MoneyField(models.DecimalField):
             raise ValueError('default value must be an instance of Money, is: %s' % default)
         return default
 
+    def check_field_attributes(self, decimal_places, max_digits):
+        """
+        Django < 1.7 has no system checks framework.
+        Avoid giving the user hard-to-debug errors if they miss required attributes.
+        """
+        if max_digits is None:
+            raise ValueError('You have to provide a max_digits attribute to Money fields.')
+        if decimal_places is None:
+            raise ValueError('You have to provide a decimal_places attribute to Money fields.')
+
     def to_python(self, value):
         if isinstance(value, Money):
             value = value.amount
@@ -324,7 +352,8 @@ class MoneyField(models.DecimalField):
     def contribute_to_class(self, cls, name):
         cls._meta.has_money_field = True
 
-        self.add_currency_field(cls, name)
+        if not self.frozen_by_south:
+            self.add_currency_field(cls, name)
 
         super(MoneyField, self).contribute_to_class(cls, name)
 
@@ -350,6 +379,11 @@ class MoneyField(models.DecimalField):
 
     def get_default(self):
         if isinstance(self.default, Money):
+            frm = inspect.stack()[1]
+            mod = inspect.getmodule(frm[0])
+            # We need to return the numerical value if this is called by south
+            if mod is not None and mod.__name__.startswith('south.db'):
+                return self.default.amount
             return self.default
         else:
             return super(MoneyField, self).get_default()
@@ -370,6 +404,21 @@ class MoneyField(models.DecimalField):
             value = self.value_from_object(obj)
         return self.get_prep_value(value)
 
+    # South support
+    def south_field_triple(self):
+        """Returns a suitable description of this field for South."""
+        # Note: This method gets automatically with schemamigration time.
+        from south.modelsinspector import introspector
+        field_class = self.__class__.__module__ + '.' + self.__class__.__name__
+        args, kwargs = introspector(self)
+        # We need to
+        # 1. Delete the default, 'cause it's not automatically supported.
+        kwargs.pop('default')
+        # 2. add the default currency, because it's not picked up from the inspector automatically.
+        kwargs['default_currency'] = "'%s'" % self.default_currency
+        return field_class, args, kwargs
+
+    # Django 1.7 migration support
     def deconstruct(self):
         name, path, args, kwargs = super(MoneyField, self).deconstruct()
 
@@ -380,6 +429,22 @@ class MoneyField(models.DecimalField):
         if self.currency_choices != CURRENCY_CHOICES:
             kwargs['currency_choices'] = self.currency_choices
         return name, path, args, kwargs
+
+
+try:
+    from south.modelsinspector import add_introspection_rules
+    rules = [
+        # MoneyField has its own method.
+        ((CurrencyField,),
+         [],  # No positional args
+         {'default': ('default', {'default': DEFAULT_CURRENCY.code}),
+          'max_length': ('max_length', {'default': 3})}),
+    ]
+
+    # MoneyField implement the serialization in south_field_triple method
+    add_introspection_rules(rules, ['^djmoney\.models\.fields\.CurrencyField'])
+except ImportError:
+    pass
 
 
 def patch_managers(sender, **kwargs):

--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -1,15 +1,20 @@
 # -*- coding: utf-8 -*-
-from django.db.models import F, Q
-from django.db.models.constants import LOOKUP_SEP
-from django.db.models.expressions import BaseExpression
+from django import VERSION
+from django.db.models import F
 from django.db.models.fields import FieldDoesNotExist
+from django.db.models.query_utils import Q
 from django.db.models.sql.constants import QUERY_TERMS
 from django.db.models.sql.query import Query
-from django.utils.six import wraps
 
 from moneyed import Money
 
-from .._compat import smart_unicode
+from .._compat import (
+    LOOKUP_SEP,
+    BaseExpression,
+    resolve_field,
+    smart_unicode,
+    wraps,
+)
 from ..utils import get_currency_field_name, prepare_expression
 from .fields import CurrencyField, MoneyField
 
@@ -24,15 +29,17 @@ def _get_clean_name(name):
 
 
 def _get_field(model, name):
-
     # Create a fake query object so we can easily work out what field
     # type we are dealing with
     qs = Query(model)
+    opts = qs.get_meta()
+    alias = qs.get_initial_alias()
+
     parts = name.split(LOOKUP_SEP)
 
     # The following is borrowed from the innards of Query.add_filter - it strips out __gt, __exact et al.
     num_parts = len(parts)
-    if num_parts > 1 and parts[-1] in Query.query_terms:
+    if num_parts > 1 and parts[-1] in qs.query_terms:
         # Traverse the lookup query to distinguish related fields from
         # lookup types.
         for counter, field_name in enumerate(parts, 1):
@@ -52,7 +59,7 @@ def _get_field(model, name):
                     parts.pop()
                     break
 
-    return qs.names_to_path(parts, qs.get_meta(), True, fail_on_missing=False)[1]
+    return resolve_field(qs, parts, opts, alias)
 
 
 def is_in_lookup(name, value):
@@ -250,8 +257,17 @@ def money_manager(manager):
     class MoneyManager(manager.__class__):
 
         def get_queryset(self, *args, **kwargs):
-            queryset = super(MoneyManager, self).get_queryset(*args, **kwargs)
-            return add_money_comprehension_to_queryset(queryset)
+            # If we are calling code that is pre-Django 1.6, need to
+            # spell it 'get_query_set'
+            s = super(MoneyManager, self)
+            method = getattr(s, 'get_queryset',
+                             getattr(s, 'get_query_set', None))
+            return add_money_comprehension_to_queryset(method(*args, **kwargs))
+
+        # If we are being called by code pre Django 1.6, need
+        # 'get_query_set'.
+        if VERSION < (1, 6):
+            get_query_set = get_queryset
 
     manager.__class__ = MoneyManager
     return manager

--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -11,6 +11,7 @@ from django.utils import six
 
 from moneyed import Money
 
+from ._compat import get_field_names
 from .models.fields import MoneyField
 from .utils import get_currency_field_name
 
@@ -39,7 +40,7 @@ def Deserializer(stream_or_string, **options):  # noqa
                     raise
             money_fields = {}
             fields = {}
-            field_names = {field.name for field in Model._meta.get_fields()}
+            field_names = get_field_names(Model)
             for (field_name, field_value) in six.iteritems(obj['fields']):
                 if ignore and field_name not in field_names:
                     # skip fields no longer on model

--- a/djmoney/utils.py
+++ b/djmoney/utils.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from django.db.models import F
-from django.db.models.expressions import BaseExpression
 
 from moneyed import Money
+
+from ._compat import BaseExpression, set_expression_rhs, split_expression
 
 
 def get_currency_field_name(name):
@@ -24,6 +25,7 @@ def prepare_expression(expr):
     """
     Prepares some complex money expression to be used in query.
     """
-    amount = get_amount(expr.rhs)
-    expr.rhs.value = amount
-    return expr.lhs
+    lhs, rhs = split_expression(expr)
+    amount = get_amount(rhs)
+    set_expression_rhs(expr, amount)
+    return lhs

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,11 @@
 Changelog
 =========
 
+Changes in 0.11.3.dev0
+----------------------
+
+- Restored support for Django < 1.8 & Python 2.6
+
 Changes in 0.11.2
 -----------------
 
@@ -213,10 +218,7 @@ Changes in 0.3
 - South support: Declare default attribute values. (`pjdelport`_)
 
 
-<<<<<<< 5f41c0aca50a966fa1fd6bbe6b092879d5443046
 .. _#300: https://github.com/django-money/django-money/issues/300
-=======
->>>>>>> Fixed access to models properties. Fixes #297
 .. _#297: https://github.com/django-money/django-money/issues/297
 .. _#292: https://github.com/django-money/django-money/issues/292
 .. _#278: https://github.com/django-money/django-money/issues/278

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,7 +6,7 @@ Changelog
 Changes in 0.11.3.dev0
 ----------------------
 
-- Restored support for Django < 1.8 & Python 2.6
+- Restored support for Django 1.4, 1.5, 1.6, and 1.7 & Python 2.6
 
 Changes in 0.11.2
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
     install_requires=[
         'setuptools',
-        'Django>=1.8',
+        'Django>=1.4',
         'py-moneyed>=0.7'
     ],
     platforms=['Any'],
@@ -65,6 +65,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',

--- a/tests/_compat.py
+++ b/tests/_compat.py
@@ -8,8 +8,10 @@ if reversion.VERSION >= (2, 0):
     from reversion.models import Version
 
     get_deleted = Version.objects.get_deleted
-else:
+elif reversion.VERSION >= (1, 10):
     from reversion.revisions import get_deleted, create_revision, register
+else:
+    from reversion import get_deleted, create_revision, register
 try:
     from mock import patch
 except ImportError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ from decimal import Decimal
 from django import VERSION
 
 import pytest
-from moneyed import Money
 
+from moneyed import Money
 from tests.testapp.models import InheritorModel, ModelWithDefaultAsInt
 
 from ._compat import patch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ from decimal import Decimal
 from django import VERSION
 
 import pytest
-
 from moneyed import Money
+
 from tests.testapp.models import InheritorModel, ModelWithDefaultAsInt
 
 from ._compat import patch

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import pytest
-
 from moneyed import Money
 
 from ..testapp.models import ModelWithVanillaMoneyField, NullMoneyFieldModel
@@ -8,7 +7,7 @@ from ..testapp.models import ModelWithVanillaMoneyField, NullMoneyFieldModel
 
 try:
     from rest_framework import serializers
-    from rest_framework.fields import empty
+    from djmoney.contrib.django_rest_framework.helpers import IS_DRF_3
 except ImportError:
     pytest.skip()
 
@@ -18,12 +17,22 @@ pytestmark = pytest.mark.django_db
 
 class TestMoneyField:
 
+    if IS_DRF_3:
+        from rest_framework.fields import empty
+    else:
+        empty = None
+
     def get_serializer(self, model_class, instance=None, data=empty):
 
-        class Serializer(serializers.ModelSerializer):
-            class Meta:
-                model = model_class
-                fields = '__all__'
+        if IS_DRF_3:
+            class Serializer(serializers.ModelSerializer):
+                class Meta:
+                    model = model_class
+                    fields = '__all__'
+        else:
+            class Serializer(serializers.ModelSerializer):
+                class Meta:
+                    model = model_class
 
         return Serializer(instance=instance, data=data)
 
@@ -33,16 +42,16 @@ class TestMoneyField:
             (
                 NullMoneyFieldModel,
                 {'field': Money(10, 'USD')},
-                {'field': '10.00', 'field_currency': 'USD'}
+                {'field': '10.00' if IS_DRF_3 else 10, 'field_currency': 'USD'}
             ),
             (
                 ModelWithVanillaMoneyField,
                 {'money': Money(10, 'USD')},
                 {
                     'integer': 0,
-                    'money': '10.00',
+                    'money': '10.00' if IS_DRF_3 else 10,
                     'money_currency': 'USD',
-                    'second_money': '0.00',
+                    'second_money': '0.00' if IS_DRF_3 else 0,
                     'second_money_currency': 'EUR'}
             ),
         )
@@ -70,7 +79,7 @@ class TestMoneyField:
     def test_invalid_value(self):
         serializer = self.get_serializer(ModelWithVanillaMoneyField, data={'money': None})
         assert not serializer.is_valid()
-        error_text = 'This field may not be null.'
+        error_text = 'This field may not be null.' if IS_DRF_3 else 'This field is required.'
         assert serializer.errors == {'money': [error_text]}
 
     @pytest.mark.parametrize(
@@ -83,4 +92,7 @@ class TestMoneyField:
     def test_post_put_values(self, body, expected):
         serializer = self.get_serializer(NullMoneyFieldModel, data=body)
         serializer.is_valid()
-        assert serializer.validated_data['field'] == expected
+        if IS_DRF_3:
+            assert serializer.validated_data['field'] == expected
+        else:
+            assert Money(serializer.data['field'], serializer.data['field_currency']) == expected

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from moneyed import Money
 
 from ..testapp.models import ModelWithVanillaMoneyField, NullMoneyFieldModel

--- a/tests/migrations/helpers.py
+++ b/tests/migrations/helpers.py
@@ -3,13 +3,15 @@
 This module contains various helpers for migrations testing.
 """
 import os
+from os.path import abspath, join
 
-from django import VERSION, setup
+from django import VERSION
 from django.core.management import call_command
-from django.core.management.commands.makemigrations import Command
 
 
-setup()
+if VERSION >= (1, 7):
+    from django import setup
+    setup()
 
 
 MIGRATION_NAME = 'test'
@@ -19,9 +21,33 @@ def makemigrations():
     os.system('find . -name \*.pyc -delete')
     if VERSION >= (1, 10):
         call_command('makemigrations', 'money_app', name=MIGRATION_NAME)
+    elif VERSION >= (1, 7):
+        run_migration_command()
     else:
-        # In Django 1.8 & 1.9 first argument name clashes with command option.
-        Command().execute('money_app', name=MIGRATION_NAME, verbosity=1)
+        if '0001_test.py' not in os.listdir(join(abspath(os.curdir), 'money_app/migrations')):
+            kwargs = {'initial': True}
+        else:
+            kwargs = {'auto': True}
+        call_command('schemamigration', 'money_app', MIGRATION_NAME, **kwargs)
+
+
+def run_migration_command():
+    """
+    In Django 1.8 & 1.9 first argument name clashes with command option.
+    In Django 1.7 there is no built-in option to name a migration.
+    """
+    from django.core.management.commands.makemigrations import Command
+
+    if VERSION < (1, 8):
+
+        class Command(Command):
+
+            def write_migration_files(self, changes):
+                migration = list(changes.items())[0][1][0]
+                migration.name = migration.name.split('_')[0] + '_' + MIGRATION_NAME
+                super(Command, self).write_migration_files(changes)
+
+    Command().execute('money_app', name=MIGRATION_NAME, verbosity=1)
 
 
 def get_migration(name):
@@ -32,5 +58,11 @@ def get_operations(migration_name):
     return get_migration(migration_name).operations
 
 
+def get_models(migration_name):
+    return get_migration(migration_name).models['money_app.model']
+
+
 def migrate():
+    if VERSION < (1, 7):
+        call_command('syncdb')
     call_command('migrate', 'money_app')

--- a/tests/migrations/test_migrations.py
+++ b/tests/migrations/test_migrations.py
@@ -1,22 +1,25 @@
 # -*- coding: utf-8 -*-
 from textwrap import dedent
 
-from django.db import migrations
+from django import VERSION
 
 import pytest
 
 from djmoney.models.fields import CurrencyField, MoneyField
 
-from .helpers import get_operations
+from .helpers import get_models, get_operations
+
+
+if VERSION >= (1, 7):
+    from django.db import migrations
+else:
+    migrations = None
 
 
 @pytest.mark.usefixtures('coveragerc')
-class TestMigrationFramework:
+class BaseMigrationTests:
     installed_apps = ['djmoney', 'money_app']
-    migration_output = [
-        '*Applying money_app.0001_test... OK*',
-        '*Applying money_app.0002_test... OK*',
-    ]
+    migration_output = ()
 
     @pytest.fixture(autouse=True)
     def setup(self, testdir):
@@ -26,15 +29,15 @@ class TestMigrationFramework:
         self.testdir = testdir
         self.project_root = testdir.mkpydir('money_app')
         testdir.makepyfile(app_settings='''
-            DATABASES = {
-                'default': {
-                    'ENGINE': 'django.db.backends.sqlite3',
-                    'NAME': ':memory:',
-                }
+        DATABASES = {
+            'default': {
+                'ENGINE': 'django.db.backends.sqlite3',
+                'NAME': ':memory:',
             }
-            INSTALLED_APPS = %s
-            SECRET_KEY = 'foobar'
-            ''' % str(self.installed_apps))
+        }
+        INSTALLED_APPS = %s
+        SECRET_KEY = 'foobar'
+        ''' % str(self.installed_apps))
         self.project_root.join('migrations/__init__.py').ensure()
         testdir.syspathinsert()
 
@@ -56,13 +59,13 @@ class TestMigrationFramework:
         else:
             fields_definition = 'pass'
         self.make_models('''
-            from django.db import models
+        from django.db import models
 
-            from djmoney.models.fields import MoneyField
+        from djmoney.models.fields import MoneyField
 
 
-            class Model(models.Model):
-                %s''' % fields_definition)
+        class Model(models.Model):
+            %s''' % fields_definition)
         return self.run('from tests.migrations.helpers import makemigrations; makemigrations();')
 
     def make_default_migration(self):
@@ -85,6 +88,113 @@ class TestMigrationFramework:
         """
         migration = self.migrate()
         migration.stdout.fnmatch_lines(self.migration_output)
+
+
+@pytest.mark.skipif(VERSION >= (1, 7), reason='Django 1.7+ has migration framework')
+class TestSouth(BaseMigrationTests):
+    """
+    Tests for South-based migrations on Django < 1.7.
+    """
+    installed_apps = BaseMigrationTests.installed_apps + ['south']
+    migration_output = [
+        '* - Migrating forwards to 0002_test.*',
+        '*> money_app:0001_test*',
+        '*> money_app:0002_test*',
+        '*- Loading initial data for money_app.*',
+    ]
+
+    def test_create_initial(self):
+        migration = self.make_default_migration()
+        migration.stderr.fnmatch_lines([
+            '*Added model money_app.Model*',
+            '*Created 0001_test.py*'
+        ])
+
+        models = get_models('0001')
+        assert models['field'] == (
+            'djmoney.models.fields.MoneyField',
+            [],
+            {
+                'max_digits': '10',
+                'decimal_places': '2',
+                'default_currency': "'XYZ'"
+            }
+        )
+        assert models['field_currency'] == ('djmoney.models.fields.CurrencyField', [], {})
+        migration = self.migrate()
+        migration.stdout.fnmatch_lines([
+            '*Creating table south_migrationhistory*',
+            '* - Migrating forwards to 0001_test.*',
+            '*> money_app:0001_test*',
+        ])
+
+    def test_alter_field(self):
+        self.make_default_migration()
+        migration = self.make_migration(field='MoneyField(max_digits=15, decimal_places=2)')
+        migration.stderr.fnmatch_lines([
+            '*~ Changed field field on money_app.Model*',
+            '*Created 0002_test.py*',
+        ])
+
+        models = get_models('0002')
+        assert models['field'] == (
+            'djmoney.models.fields.MoneyField',
+            [],
+            {'max_digits': '15', 'decimal_places': '2', 'default_currency': "'XYZ'"}
+        )
+        assert models['field_currency'] == ('djmoney.models.fields.CurrencyField', [], {})
+        self.assert_migrate()
+
+    def test_add_field(self):
+        self.make_default_migration()
+        migration = self.make_migration(
+            field='MoneyField(max_digits=10, decimal_places=2)',
+            value="MoneyField(max_digits=5, decimal_places=2, default_currency='GBP')"
+        )
+        migration.stderr.fnmatch_lines(['*+ Added field value_currency on money_app.Model*'])
+        migration.stderr.fnmatch_lines([
+            '*+ Added field value on money_app.Model*',
+            '*Created 0002_test.py*',
+        ])
+
+        models = get_models('0002')
+        assert models['field'] == (
+            'djmoney.models.fields.MoneyField',
+            [],
+            {'max_digits': '10', 'decimal_places': '2', 'default_currency': "'XYZ'"}
+        )
+        assert models['field_currency'] == ('djmoney.models.fields.CurrencyField', [], {})
+        assert models['value'] == (
+            'djmoney.models.fields.MoneyField',
+            [],
+            {'max_digits': '5', 'decimal_places': '2', 'default_currency': "'GBP'"}
+        )
+        assert models['value_currency'] == ('djmoney.models.fields.CurrencyField', [], {'default': "'GBP'"})
+        self.assert_migrate()
+
+    def test_remove_field(self):
+        self.make_default_migration()
+        migration = self.make_migration()
+        migration.stderr.fnmatch_lines(['*- Deleted field field_currency on money_app.Model*'])
+        migration.stderr.fnmatch_lines([
+            '*- Deleted field field on money_app.Model*',
+            '*Created 0002_test.py*',
+        ])
+
+        models = get_models('0002')
+        assert models == {
+            'Meta': {'object_name': 'Model'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        }
+        self.assert_migrate()
+
+
+@pytest.mark.skipif(VERSION < (1, 7), reason='Django 1.7+ has migration framework')
+class TestMigrationFramework(BaseMigrationTests):
+    migration_output = [
+        '*Applying money_app.0001_test... OK*',
+        '*Applying money_app.0002_test... OK*',
+    ]
 
     def test_create_initial(self):
         migration = self.make_default_migration()

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,11 +1,11 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-import django.contrib.admin.utils as admin_utils
 from django import VERSION
 
 import pytest
 
+from djmoney._compat import admin_utils
 from moneyed import Money
 
 from .testapp.models import ModelWithVanillaMoneyField
@@ -19,7 +19,7 @@ def get_args(value, field):
     """
     Constructs arguments for `display_for_field`.
     """
-    if VERSION[:2] == (1, 8):
+    if VERSION < (1, 9):
         return value, field
     return value, field, ''
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -28,6 +28,7 @@ from .testapp.models import ModelWithVanillaMoneyField, NullMoneyFieldModel
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.xfail(VERSION[:3] == (1, 10, 1), reason='Bug in this Django version.', strict=True)
 def test_save():
     money = Money(Decimal('10'), moneyed.SEK)
     form = MoneyModelForm({'money_0': money.amount, 'money_1': money.currency})

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -3,6 +3,7 @@ from django.db.models import F, Q
 
 import pytest
 
+from djmoney._compat import split_expression
 from djmoney.models.managers import _expand_money_args, _expand_money_kwargs
 from djmoney.utils import get_amount
 from moneyed import Money
@@ -163,7 +164,8 @@ class TestKwargsExpand:
         _, kwargs = _expand_money_kwargs(ModelWithNonMoneyField, kwargs=value)
         assert isinstance(kwargs['money_currency'], F)
         assert kwargs['money_currency'].name == 'money_currency'
-        assert get_amount(kwargs['money'].rhs) == expected
+        rhs = split_expression(kwargs['money'])[1]
+        assert get_amount(rhs) == expected
 
     def test_simple_f_query(self):
         _, kwargs = _expand_money_kwargs(ModelWithNonMoneyField, kwargs={'money': F('money')})

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,7 +18,6 @@ from django.utils.translation import override
 import pytest
 
 import moneyed
-
 from djmoney._compat import Case, Func, Value, When, get_fields
 from djmoney.models.fields import MoneyField, MoneyPatched
 from moneyed import Money

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,14 +11,15 @@ from decimal import Decimal
 from django import VERSION
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
-from django.db.migrations.writer import MigrationWriter
-from django.db.models import Case, F, Func, Q, Value, When
+from django.db.models import F, Q
 from django.utils.six import PY2
 from django.utils.translation import override
 
 import pytest
 
 import moneyed
+
+from djmoney._compat import Case, Func, Value, When, get_fields
 from djmoney.models.fields import MoneyField, MoneyPatched
 from moneyed import Money
 
@@ -46,6 +47,10 @@ from .testapp.models import (
     ProxyModel,
     SimpleModel,
 )
+
+
+if VERSION >= (1, 7):
+    from django.db.migrations.writer import MigrationWriter
 
 
 pytestmark = pytest.mark.django_db
@@ -176,10 +181,12 @@ class TestVanillaMoneyField:
         assert DateTimeModel.objects.filter(created__date='2016-12-01').count() == 0
         assert DateTimeModel.objects.filter(created__date='2016-12-05').count() == 1
 
+    skip_lookup = pytest.mark.skipif(VERSION < (1, 6), reason='This lookup doesn\'t play well on Django < 1.6')
+
     @pytest.mark.parametrize('lookup, rhs, expected', (
         ('startswith', 2, 1),
-        ('regex', '^[134]', 3),
-        ('iregex', '^[134]', 3),
+        skip_lookup(('regex', '^[134]', 3)),
+        skip_lookup(('iregex', '^[134]', 3)),
         ('istartswith', 2, 1),
         ('contains', 5, 2),
         ('lt', 5, 4),
@@ -365,6 +372,7 @@ class TestFExpressions:
         instance = ModelWithVanillaMoneyField.objects.create(**create_kwargs)
         assert (instance in ModelWithVanillaMoneyField.objects.filter(**filter_value)) is in_result
 
+    @pytest.mark.skipif(VERSION < (1, 5), reason='Django < 1.5 does not support `update_fields` kwarg')
     def test_update_fields_save(self):
         instance = ModelWithVanillaMoneyField.objects.create(money=Money(100, 'USD'), integer=2)
         instance.money = F('money') + Money(100, 'USD')
@@ -379,10 +387,13 @@ class TestFExpressions:
         F('money') % F('money'),
         F('money') + F('integer'),
         F('money') + F('second_money'),
-        F('money') ** F('money'),
-        F('money') ** F('integer'),
-        F('money') ** 2,
     ]
+    if VERSION >= (1, 7):
+        INVALID_EXPRESSIONS.extend([
+            F('money') ** F('money'),
+            F('money') ** F('integer'),
+            F('money') ** 2,
+        ])
 
     @pytest.mark.parametrize('f_obj', INVALID_EXPRESSIONS)
     def test_invalid_expressions_access(self, f_obj):
@@ -391,6 +402,7 @@ class TestFExpressions:
             instance.money = f_obj
 
 
+@pytest.mark.skipif(VERSION < (1, 8), reason='Only Django 1.8+ supports query expressions')
 class TestExpressions:
 
     def test_conditional_update(self):
@@ -567,12 +579,17 @@ def test_different_hashes():
     assert hash(money) != hash(money_currency)
 
 
+@pytest.mark.skipif(VERSION < (1, 7), reason='Django < 1.7 handles migrations differently')
 def test_migration_serialization():
+    imports = set(['import djmoney.models.fields'])
     if PY2:
         serialized = 'djmoney.models.fields.MoneyPatched(100, b\'GBP\')'
     else:
         serialized = 'djmoney.models.fields.MoneyPatched(100, \'GBP\')'
-    assert MigrationWriter.serialize(MoneyPatched(100, 'GBP')) == (serialized, {'import djmoney.models.fields'})
+    assert MigrationWriter.serialize(MoneyPatched(100, 'GBP')) == (serialized, imports)
+
+
+no_system_checks_framework = pytest.mark.skipif(VERSION >= (1, 7), reason='Django 1.7+ has system checks framework')
 
 
 class TestFieldAttributes:
@@ -587,10 +604,19 @@ class TestFieldAttributes:
 
         return Model
 
-    def test_missing_attributes(self):
+    @pytest.mark.parametrize('field_kwargs, message', (
+        no_system_checks_framework(
+            ({'max_digits': 10}, 'You have to provide a decimal_places attribute to Money fields.')
+        ),
+        no_system_checks_framework(
+            ({'decimal_places': 2}, 'You have to provide a max_digits attribute to Money fields.')
+        ),
+        ({'default': {}}, 'default value must be an instance of Money, is: {}'),
+    ))
+    def test_missing_attributes(self, field_kwargs, message):
         with pytest.raises(ValueError) as exc:
-            self.create_class(default={})
-        assert str(exc.value) == 'default value must be an instance of Money, is: {}'
+            self.create_class(**field_kwargs)
+        assert str(exc.value) == message
 
     def test_default_currency(self):
         klass = self.create_class(default_currency=None, default=Money(10, 'EUR'), max_digits=10, decimal_places=2)
@@ -613,7 +639,7 @@ def test_hash_uniqueness():
     """
     All fields of any model should have unique hash.
     """
-    hashes = [hash(field) for field in ModelWithVanillaMoneyField._meta.get_fields()]
+    hashes = [hash(field) for field in get_fields(ModelWithVanillaMoneyField)]
     assert len(hashes) == len(set(hashes))
 
 

--- a/tests/test_reversion.py
+++ b/tests/test_reversion.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from moneyed import Money
 
 from ._compat import create_revision, get_deleted

--- a/tests/test_reversion.py
+++ b/tests/test_reversion.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import pytest
-
 from moneyed import Money
 
 from ._compat import create_revision, get_deleted

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 
+from django import VERSION
 from django.core.management import call_command
 from django.core.serializers.base import DeserializationError
 
@@ -13,6 +14,14 @@ from .testapp.models import ModelWithDefaultAsInt
 
 
 pytestmark = pytest.mark.django_db
+
+not_django14 = pytest.mark.skipif(VERSION[:3] < (1, 5), reason="Django 1.4 doesn't support ignorenonexistent option")
+
+
+if VERSION[:3] < (1, 8):
+    ignore = 'ignore'
+else:
+    ignore = 'ignorenonexistent'
 
 
 def test_m2m_fields_are_not_lost(concrete_instance, m2m_object):
@@ -35,7 +44,7 @@ def dumpdata(capsys):
 
 
 def loaddata(fixture_file, ignore_value=False):
-    call_command('loaddata', str(fixture_file), **{'ignorenonexistent': ignore_value})
+    call_command('loaddata', str(fixture_file), **{ignore: ignore_value})
 
 
 def test_dumpdata(capsys, fixture_file):
@@ -48,13 +57,19 @@ def test_dumpdata(capsys, fixture_file):
     assert ModelWithDefaultAsInt.objects.get().money == money
 
 
-def test_load_invalid(fixture_file):
+def test_load_invalid(capsys, fixture_file):
     data = '[{"model": "testapp.unknown_model", "pk": 1, "fields": {"money_currency": "USD", "money": "1.00"}}]'
     fixture_file.write(data)
-    with pytest.raises(DeserializationError):
+    if VERSION[:2] == (1, 4):
+        # In Django 1.4 exceptions are in stderr
         loaddata(fixture_file)
+        assert "DeserializationError: Invalid model identifier: 'testapp.unknown_model'" in capsys.readouterr()[1]
+    else:
+        with pytest.raises(DeserializationError):
+            loaddata(fixture_file)
 
 
+@not_django14
 def test_load_invalid_ignore(fixture_file):
     data = '[{"model": "testapp.unknown_model", "pk": 1, "fields": {"money_currency": "USD", "money": "1.00"}}, ' \
            '{"model": "testapp.modelwithdefaultasint", "pk": 2, "fields": {"money_currency": "USD", "money": "1.00"}}]'
@@ -62,6 +77,7 @@ def test_load_invalid_ignore(fixture_file):
     loaddata(fixture_file, True)
 
 
+@not_django14
 def test_old_fields_skip(capsys, fixture_file):
     money = Money(10, 'EUR')
     instance = ModelWithDefaultAsInt.objects.create(money=money)

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -6,9 +6,11 @@ Created on May 7, 2011
 """
 from decimal import Decimal
 
+from django import VERSION
 from django.db import models
 
 import moneyed
+
 from djmoney.models.fields import MoneyField
 from djmoney.models.managers import money_manager, understands_money
 
@@ -137,6 +139,14 @@ class ModelWithCustomManager(models.Model):
 class DateTimeModel(models.Model):
     field = MoneyField(max_digits=10, decimal_places=2)
     created = models.DateTimeField(null=True, blank=True)
+
+
+if VERSION < (1, 7, 0):
+    from djmoney.contrib.django_rest_framework import register_money_field
+    from djmoney.admin import setup_admin_integration
+
+    register_money_field()
+    setup_admin_integration()
 
 
 class ModelIssue300(models.Model):

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -10,7 +10,6 @@ from django import VERSION
 from django.db import models
 
 import moneyed
-
 from djmoney.models.fields import MoneyField
 from djmoney.models.managers import money_manager, understands_money
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,25 @@ envlist =
     django111-py{36,35,34,27,py}
     django{110,19}-py{35,34,27,py}
     django18-py{35,34,33,32,27,py,py3}
+    django17-py{34,33,32,27,py,py3}
+    django{16,15}-py{33,32,27,26,py,py3}
+    django14-py{27,26,py}
     lint
     docs
 skipsdist = true
 
 [testenv]
 deps =
+    django14: {[django]1.4.x}
+    django15: {[django]1.5.x}
+    django16: {[django]1.6.x}
+    django17: {[django]1.7.x}
     django18: {[django]1.8.x}
     django19: {[django]1.9.x}
     django110: {[django]1.10.x}
     django111: {[django]1.11.x}
     django_master: {[django]master}
-    py27,py32,pypy: mock
+    py26,py27,py32,pypy: mock
     py32: coverage==3.7.1
     pytest<3.0.0
     pytest-django<3.0.0
@@ -33,6 +40,25 @@ commands =
     isort -rc -c {toxinidir}/djmoney {toxinidir}/tests
 
 [django]
+1.4.x  =
+       Django>=1.4.0,<1.5.0
+       django-reversion==1.6.6
+       south>=0.8.2
+       djangorestframework==2.4.8
+1.5.x  =
+       Django>=1.5.0,<1.6.0
+       django-reversion==1.7.2
+       south>=0.8.2
+       djangorestframework==2.4.8
+1.6.x  =
+       Django>=1.6.0,<1.7.0
+       django-reversion==1.8.5
+       south>=0.8.2
+       djangorestframework==2.4.8
+1.7.x  =
+       Django>=1.7.0,<1.8.0
+       django-reversion==1.10.0
+       djangorestframework==2.4.8
 1.8.x  =
        Django>=1.8.0,<1.9.0
        django-reversion==1.10.0


### PR DESCRIPTION
I reverted a few commits about dropping compatibility. If this PR will be merged, then 0.11.x branch will still have a support for Django < 1.8 and Python 2.6 as well as latest bugfixes in master.
And it will not be frustrating to users to upgrade to latest minor release in the 0.11.x branch.

As a summary my plan is:

- Restore compatibility in 0.11.x branch
- Make a new 0.11.3 release from this branch
- Change version to 0.12.dev0 in master branch
- Finish some PRs (#283, #261 ), add upgrade instructions and make a 0.12 release, which will break compatibility.

Does it seem suitable?

Kind Regards,