### PR TITLE
Custom name for CurrencyField. Shared currency. Closes #195

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -92,7 +92,7 @@ class MoneyFieldProxy(object):
 
     def __init__(self, field):
         self.field = field
-        self.currency_field_name = self.field.currency_field_name or get_currency_field_name(self.field.name)
+        self.currency_field_name = get_currency_field_name(self.field.name, self.field)
 
     def _money_from_obj(self, obj):
         amount = obj.__dict__[self.field.name]
@@ -241,10 +241,7 @@ class MoneyField(models.DecimalField):
     def contribute_to_class(self, cls, name):
         cls._meta.has_money_field = True
 
-        currency_field_name = self.currency_field_name or get_currency_field_name(name)
-
-        # if not hasattr(cls, currency_field_name):
-        self.add_currency_field(cls, currency_field_name)
+        self.add_currency_field(cls, name)
 
         super(MoneyField, self).contribute_to_class(cls, name)
 
@@ -260,7 +257,8 @@ class MoneyField(models.DecimalField):
             choices=self.currency_choices
         )
         currency_field.creation_counter = self.creation_counter - 1
-        cls.add_to_class(name, currency_field)
+        currency_field_name = get_currency_field_name(name, self)
+        cls.add_to_class(currency_field_name, currency_field)
 
     def get_db_prep_save(self, value, connection):
         if isinstance(value, MONEY_CLASSES):

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -141,7 +141,7 @@ class MoneyFieldProxy(object):
         # But we should also allow setting a field back to its original default
         # value!
         # https://github.com/django-money/django-money/issues/221
-        object_currency = obj.__dict__[self.currency_field_name]
+        object_currency = obj.__dict__.get(self.currency_field_name)
         if object_currency != value:
             # in other words, update the currency only if it wasn't
             # changed before.

--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -73,20 +73,22 @@ def _convert_in_lookup(model, field_name, options):
     new_query = Q()
     for value in options:
         if isinstance(value, MONEY_CLASSES):
-            option = Q(**{
+            # amount__in=[Money(1, 'EUR'), Money(2, 'EUR')]
+            option = {
                 field.name: value.amount,
                 get_currency_field_name(field.name, field): value.currency
-            })
+            }
         elif isinstance(value, F):
             # amount__in=[Money(1, 'EUR'), F('another_money')]
             target_field = _get_field(model, value.name)
-            option = Q(**{
+            option = {
                 field.name: value,
                 get_currency_field_name(field.name, field): F(get_currency_field_name(value.name, target_field))
-            })
+            }
         else:
-            option = Q(**{field.name: value})
-        new_query |= option
+            # amount__in=[1, 2, 3]
+            option = {field.name: value}
+        new_query |= Q(**option)
     return new_query
 
 

--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -143,10 +143,7 @@ def _expand_money_kwargs(model, args=(), kwargs=None, exclusions=()):
         if isinstance(value, MONEY_CLASSES):
             clean_name = _get_clean_name(name)
             kwargs[name] = value.amount
-            if isinstance(field, MoneyField) and field.currency_field_name:
-                currency_field_name = field.currency_field_name
-            else:
-                currency_field_name = get_currency_field_name(clean_name)
+            currency_field_name = get_currency_field_name(clean_name, field)
             kwargs[currency_field_name] = smart_unicode(value.currency)
         else:
             if isinstance(field, MoneyField):
@@ -156,10 +153,7 @@ def _expand_money_kwargs(model, args=(), kwargs=None, exclusions=()):
                         value = prepare_expression(value)
                     if not _is_money_field(model, value, name):
                         continue
-                    if field.currency_field_name:
-                        currency_field_name = field.currency_field_name
-                    else:
-                        currency_field_name = get_currency_field_name(clean_name)
+                    currency_field_name = get_currency_field_name(clean_name, field)
                     kwargs[currency_field_name] = F(get_currency_field_name(value.name))
                 if is_in_lookup(name, value):
                     args += (_convert_in_lookup(model, name, value), )

--- a/djmoney/utils.py
+++ b/djmoney/utils.py
@@ -9,7 +9,9 @@ from moneyed import Money as OldMoney
 MONEY_CLASSES = (Money, OldMoney)
 
 
-def get_currency_field_name(name):
+def get_currency_field_name(name, field=None):
+    if field and getattr(field, 'currency_field_name', None):
+        return field.currency_field_name
     return '%s_currency' % name
 
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+- Ability to specify name for currency field. `#195`_ (`Stranger6667`_)
+
 Changed
 ~~~~~~~
 - Improved ``Money`` support. Now ``django-money`` fully relies on ``pymoneyed`` localization everywhere, including Django admin. `#276`_ (`Stranger6667`_)
@@ -434,6 +439,7 @@ Added
 .. _#199: https://github.com/django-money/django-money/issues/199
 .. _#198: https://github.com/django-money/django-money/issues/198
 .. _#196: https://github.com/django-money/django-money/issues/196
+.. _#195: https://github.com/django-money/django-money/issues/195
 .. _#194: https://github.com/django-money/django-money/issues/194
 .. _#186: https://github.com/django-money/django-money/issues/186
 .. _#184: https://github.com/django-money/django-money/issues/184

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,13 +40,13 @@ from .testapp.models import (
     ModelWithDefaultAsString,
     ModelWithDefaultAsStringWithCurrency,
     ModelWithNonMoneyField,
+    ModelWithSharedCurrency,
     ModelWithTwoMoneyFields,
     ModelWithUniqueIdAndCurrency,
     ModelWithVanillaMoneyField,
     NullMoneyFieldModel,
     ProxyModel,
     SimpleModel,
-    ModelWithSharedCurrency,
 )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -46,6 +46,7 @@ from .testapp.models import (
     NullMoneyFieldModel,
     ProxyModel,
     SimpleModel,
+    ModelWithSharedCurrency,
 )
 
 
@@ -671,3 +672,12 @@ def test_properties_access():
     with pytest.raises(TypeError) as exc:
         ModelWithVanillaMoneyField(money=Money(1, 'USD'), bla=1)
     assert str(exc.value) == "'bla' is an invalid keyword argument for this function"
+
+
+def test_shared():
+    instance = ModelWithSharedCurrency.objects.create(first=10, second=15, currency='USD')
+    assert instance.first == Money(10, 'USD')
+    assert instance.second == Money(15, 'USD')
+    assert instance.currency == 'USD'
+    assert instance in ModelWithSharedCurrency.objects.filter(first=Money(10, 'USD'))
+    assert instance not in ModelWithSharedCurrency.objects.filter(first=Money(10, 'EUR'))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -708,3 +708,9 @@ class TestSharedCurrency:
     @parametrize_with_q(first__in=[Money(10, 'USD'), Money(100, 'USD')])
     def test_in_lookup(self, instance, args, kwargs):
         assert instance in ModelWithSharedCurrency.objects.filter(*args, **kwargs)
+
+    def test_create_with_money(self):
+        value = Money(10, 'USD')
+        instance = ModelWithSharedCurrency.objects.create(first=value, second=value)
+        assert instance.first == value
+        assert instance.second == value

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -152,3 +152,8 @@ class ModelIssue300(models.Model):
 
 class ModelWithValidation(models.Model):
     balance = MoneyField(max_digits=10, decimal_places=2, validators=[MinValueValidator(Money(100, 'GBP'))])
+
+
+class ModelWithSharedCurrency(models.Model):
+    first = MoneyField(max_digits=10, decimal_places=2, currency_field_name='currency')
+    second = MoneyField(max_digits=10, decimal_places=2, currency_field_name='currency')


### PR DESCRIPTION
Addressing #195. This PR adds an ability to specify a name on CurrencyField in a backward-compatible way, which allows users to use a single currency field for all MoneyFields. For example:

```python
class ModelWithSharedCurrency(models.Model):
    first = MoneyField(max_digits=10, decimal_places=2, currency_field_name='currency')
    second = MoneyField(max_digits=10, decimal_places=2, currency_field_name='currency')
```

This model will have only 1 currency column - "currency".