### PR TITLE
[WIP] Fix querying on related models. Fixes #327

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,7 @@ Fixed
 - Fixed ``F`` expressions support for ``in`` lookups. `#321`_ (`Stranger6667`_).
 - Fixed money comprehension on querysets. `#331`_ (`Stranger6667`_, `jaavii1988`_).
 - Fixed errors in Django Admin integration. `#334`_ (`Stranger6667`_, `adi-`_).
+- Fixed respecting currency in filtration on related models. `#327`_ (`Stranger6667`_).
 
 Removed
 ~~~~~~~
@@ -415,6 +416,7 @@ Added
 .. _#337: https://github.com/django-money/django-money/issues/337
 .. _#334: https://github.com/django-money/django-money/issues/334
 .. _#331: https://github.com/django-money/django-money/issues/331
+.. _#327: https://github.com/django-money/django-money/issues/327
 .. _#321: https://github.com/django-money/django-money/issues/321
 .. _#318: https://github.com/django-money/django-money/issues/318
 .. _#309: https://github.com/django-money/django-money/issues/309

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -471,12 +471,21 @@ class TestExpressions:
         assert ModelWithVanillaMoneyField.objects.get(Q(money=F('integer') + 1)) == instance
 
 
-def test_find_models_related_to_money_models():
-    moneyModel = ModelWithVanillaMoneyField.objects.create(money=Money('100.0', 'ZWN'))
-    ModelRelatedToModelWithMoney.objects.create(moneyModel=moneyModel)
+class TestFindModelsRelatedToMoneyModels:
 
-    ModelRelatedToModelWithMoney.objects.get(moneyModel__money=Money('100.0', 'ZWN'))
-    ModelRelatedToModelWithMoney.objects.get(moneyModel__money__lt=Money('1000.0', 'ZWN'))
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        moneyModel = ModelWithVanillaMoneyField.objects.create(money=Money(100, 'ZWN'))
+        self.instance = ModelRelatedToModelWithMoney.objects.create(moneyModel=moneyModel)
+
+    def test_exact(self):
+        assert ModelRelatedToModelWithMoney.objects.get(moneyModel__money=Money(100, 'ZWN')) == self.instance
+
+    def test_lt(self):
+        assert ModelRelatedToModelWithMoney.objects.get(moneyModel__money__lt=Money(1000, 'ZWN')) == self.instance
+
+    def test_different_currency(self):
+        assert not ModelRelatedToModelWithMoney.objects.filter(moneyModel__money=Money(100, 'EUR')).exists()
 
 
 def test_allow_expression_nodes_without_money():


### PR DESCRIPTION
Thoughts:

Patching should be done after all models are loaded, and then the models' graph should be traversed and appropriate managers should be patched. 

Basically, all models that could be reached from some model with money should be patched because the money model could be queried from them. So, the thing is to find all strongly connected components containing at least one money model and patch all models in these components.

Related algorithm: Kosaraju SCC

I'm not sure if bringing this kind of complexity worth it, but it should solve the problem. Anyway, I already implemented the algorithm a few months ago, so it could be adapted for this purpose.

Alternatively, we can patch all managers