### PR TITLE
Fix example for `CURRENCY_CHOICES`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,7 @@ Additionally there is an ability to specify currency choices directly:
 .. code:: python
 
         CURRENCIES = ('USD', 'EUR')
-        CURRENCY_CHOICES = (('USD', 'USD $'), ('EUR', 'EUR €'))
+        CURRENCY_CHOICES = [('USD', 'USD $'), ('EUR', 'EUR €')]
 
 Important note on model managers
 --------------------------------


### PR DESCRIPTION
Existing example results in:

```python
AttributeError: 'tuple' object has no attribute 'sort'
```

This error and solution has already been mentioned by @ChessSpider at https://github.com/django-money/django-money/issues/211#issuecomment-303083655.