### PR TITLE
Replace field.rel.to with field.remote_field.model

### DIFF
--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import django
 from django.db.models import Case, F, Q
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import BaseExpression
@@ -43,7 +44,10 @@ def _get_field(model, name):
             # to continue traversing relations.
             if counter < num_parts:
                 try:
-                    model = lookup_field.rel.to
+                    if django.VERSION < (1, 10):
+                        model = lookup_field.rel.to
+                    else:
+                        model = lookup_field.remote_field.model
                 except AttributeError:
                     # Not a related field. Bail out.
                     parts.pop()

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Fixed
 ~~~~~
 
 - Fixed migrations on SQLite. `#139`_, `#338`_ (`Stranger6667`_)
+- Fixed ``Field.rel.to`` usage for Django 2.0. `#349`_ (`richardowen`_)
 
 `0.12`_ - 2017-10-22
 --------------------


### PR DESCRIPTION
`Field.rel` and `Field.remote_field.to` are removed in Django 2.x.
This fixes compatibility with Django 2.x, prevents warnings being emitted on 1.10 & 1.11 and keeps backwards compatibility with 1.8.