### PR TITLE
Fixed Django REST Framework behaviour for serializers without `*_curr…

### DIFF
--- a/djmoney/contrib/django_rest_framework/fields.py
+++ b/djmoney/contrib/django_rest_framework/fields.py
@@ -13,7 +13,13 @@ class MoneyField(DecimalField):
     """
 
     def to_representation(self, obj):
-        return super(MoneyField, self).to_representation(obj.amount)
+        """
+        When ``field_currency`` is not in ``self.validated_data`` then ``obj`` is an instance of ``Decimal``, otherwise
+        it is ``Money``.
+        """
+        if isinstance(obj, MONEY_CLASSES):
+            obj = obj.amount
+        return super(MoneyField, self).to_representation(obj)
 
     def to_internal_value(self, data):
         if isinstance(data, MONEY_CLASSES):

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Fixed
 
 - Fixed migrations on SQLite. `#139`_, `#338`_ (`Stranger6667`_)
 - Fixed ``Field.rel.to`` usage for Django 2.0. `#349`_ (`richardowen`_)
+- Fixed Django REST Framework behaviour for serializers without `*_currency` field in serializer's ``Meta.fields``. `#351`_ (`elcolie`_, `Stranger6667`_)
 
 `0.12`_ - 2017-10-22
 --------------------
@@ -422,6 +423,7 @@ Added
 .. _0.3.1: https://github.com/django-money/django-money/compare/0.3...0.3.1
 .. _0.3: https://github.com/django-money/django-money/compare/0.2...0.3
 
+.. _#351: https://github.com/django-money/django-money/issues/351
 .. _#349: https://github.com/django-money/django-money/pull/349
 .. _#338: https://github.com/django-money/django-money/issues/338
 .. _#337: https://github.com/django-money/django-money/issues/337
@@ -499,6 +501,7 @@ Added
 .. _devlocal: https://github.com/devlocal
 .. _dnmellen: https://github.com/dnmellen
 .. _edwinlunando: https://github.com/edwinlunando
+.. _elcolie: https://github.com/elcolie
 .. _eriktelepovsky: https://github.com/eriktelepovsky
 .. _glarrain: https://github.com/glarrain
 .. _graik: https://github.com/graik

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -13,12 +13,12 @@ fields = pytest.importorskip('rest_framework.fields')
 
 class TestMoneyField:
 
-    def get_serializer(self, model_class, instance=None, data=fields.empty):
+    def get_serializer(self, model_class, instance=None, data=fields.empty, fields_='__all__'):
 
         class Serializer(serializers.ModelSerializer):
             class Meta:
                 model = model_class
-                fields = '__all__'
+                fields = fields_
 
         return Serializer(instance=instance, data=data)
 
@@ -79,3 +79,8 @@ class TestMoneyField:
         serializer = self.get_serializer(NullMoneyFieldModel, data=body)
         serializer.is_valid()
         assert serializer.validated_data['field'] == expected
+
+    def test_serializer_with_fields(self):
+        serializer = self.get_serializer(ModelWithVanillaMoneyField, data={'money': '10.00'}, fields_=('money', ))
+        serializer.is_valid(True)
+        assert serializer.data == {'money': '10.00'}


### PR DESCRIPTION
…ency` field in serializer's ``Meta.fields``. Fixes #351