### PR TITLE
Change the latest Django version to use _val_from_obj

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -283,7 +283,7 @@ class MoneyField(models.DecimalField):
         return super(MoneyField, self).formfield(**defaults)
 
     def value_to_string(self, obj):
-        if VERSION < (2, 0):
+        if VERSION < (1, 9):
             value = self._get_val_from_obj(obj)
         else:
             value = self.value_from_object(obj)


### PR DESCRIPTION
This method has been deprecated since Django 1.9, so it raises a `DeprecationWarning` since then.

https://github.com/django/django/blob/1.9/django/db/models/fields/__init__.py#L836-L839
https://github.com/django/django/commit/035b0fa60da2e758d0ab7f9d04ef93cdb73c981f