### PR TITLE
Fix BaseMoneyValidator with falsy limit values

### DIFF
--- a/djmoney/models/validators.py
+++ b/djmoney/models/validators.py
@@ -29,7 +29,7 @@ class BaseMoneyValidator(BaseValidator):
     def __call__(self, value):
         cleaned = self.clean(value)
         limit_value = self.get_limit_value(cleaned)
-        if not limit_value:
+        if limit_value is None:
             return
         if isinstance(limit_value, (int, Decimal)):
             cleaned = cleaned.amount

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,7 +6,7 @@ Changelog
 `Unreleased`_
 -------------
 
-- WIP
+- Fixed `BaseMoneyValidator` with falsy limit values. `#371`_ (`1337`_)
 
 
 `0.12.2`_ - 2017-12-12
@@ -445,6 +445,7 @@ Added
 .. _0.3: https://github.com/django-money/django-money/compare/0.2...0.3
 .. _0.2: https://github.com/django-money/django-money/compare/0.2...a6d90348085332a393abb40b86b5dd9505489b04
 
+.. _#371: https://github.com/django-money/django-money/issues/371
 .. _#366: https://github.com/django-money/django-money/issues/366
 .. _#364: https://github.com/django-money/django-money/issues/364
 .. _#361: https://github.com/django-money/django-money/issues/361
@@ -561,3 +562,4 @@ Added
 .. _yellow-sky: https://github.com/yellow-sky
 .. _w00kie: https://github.com/w00kie
 .. _willhcr: https://github.com/willhcr
+.. _1337: https://github.com/1337

--- a/tests/testapp/forms.py
+++ b/tests/testapp/forms.py
@@ -15,6 +15,7 @@ from .models import (
     ModelWithValidation,
     ModelWithVanillaMoneyField,
     NullMoneyFieldModel,
+    PositiveValidatedMoneyModel,
     ValidatedMoneyModel,
 )
 
@@ -63,4 +64,11 @@ class ValidatedMoneyModelForm(forms.ModelForm):
 
     class Meta:
         model = ValidatedMoneyModel
+        fields = ('money', )
+
+
+class PositiveValidatedMoneyModelForm(forms.ModelForm):
+
+    class Meta:
+        model = PositiveValidatedMoneyModel
         fields = ('money', )

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -172,3 +172,13 @@ class ValidatedMoneyModel(models.Model):
             MaxMoneyValidator(1500),
         ]
     )
+
+
+class PositiveValidatedMoneyModel(models.Model):
+    """Validated model with a field requiring a non-negative value."""
+    money = MoneyField(
+        max_digits=10, decimal_places=2,
+        validators=[
+            MinMoneyValidator(0),
+        ]
+    )


### PR DESCRIPTION
Fixes issue #371

* `MinMoneyValidator(0)` must allow 0, 1, and disallow -1 of a currency.
* `MaxMoneyValidator(0)` should also allow 0, and only other negative amounts of currency.

Made some forms and models that seem redundant. Please let me know if there are better ways to go about it.