### PR TITLE
Change import of convert_money

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,11 +45,13 @@ Installation
 
 Using `pip`:
 
-   pip install django-money
+.. code:: bash
+
+   $ pip install django-money
 
 This automatically installs ``py-moneyed`` v0.7 (or later).
 
-Add ``djmoney`` to your `INSTALLED_APPS`. This is required so that money field are displayed correctly in the admin.
+Add ``djmoney`` to your ``INSTALLED_APPS``. This is required so that money field are displayed correctly in the admin.
 
 .. code:: python
 
@@ -62,7 +64,7 @@ Add ``djmoney`` to your `INSTALLED_APPS`. This is required so that money field a
 Model usage
 -----------
 
-Use as normal model fields
+Use as normal model fields:
 
 .. code:: python
 

--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -11,7 +11,6 @@ from django.utils.safestring import mark_safe
 from moneyed import Currency, Money as DefaultMoney
 from moneyed.localization import _FORMATTER, format_money
 
-from .contrib.exchange.models import convert_money
 from .settings import DECIMAL_PLACES
 
 
@@ -97,5 +96,7 @@ def maybe_convert(value, currency):
     Converts other Money instances to the local currency if `AUTO_CONVERT_MONEY` is set to True.
     """
     if getattr(settings, 'AUTO_CONVERT_MONEY', False):
+        from .contrib.exchange.models import convert_money
+
         return convert_money(value, currency)
     return value

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,7 +36,7 @@ For more information, look at ``Working with Exchange Rates`` section in README.
 Fixed
 ~~~~~
 
-- Fixed `BaseMoneyValidator` with falsy limit values. `#371`_ (`1337`_)
+- Fixed ``BaseMoneyValidator`` with falsy limit values. `#371`_ (`1337`_)
 
 `0.12.2`_ - 2017-12-12
 ----------------------
@@ -59,7 +59,7 @@ Fixed
 
 - Fixed migrations on SQLite. `#139`_, `#338`_ (`Stranger6667`_)
 - Fixed ``Field.rel.to`` usage for Django 2.0. `#349`_ (`richardowen`_)
-- Fixed Django REST Framework behaviour for serializers without `*_currency` field in serializer's ``Meta.fields``. `#351`_ (`elcolie`_, `Stranger6667`_)
+- Fixed Django REST Framework behaviour for serializers without ``*_currency`` field in serializer's ``Meta.fields``. `#351`_ (`elcolie`_, `Stranger6667`_)
 
 `0.12`_ - 2017-10-22
 --------------------
@@ -189,7 +189,7 @@ Fixed
 `0.9.0`_ - 2016-07-31
 ---------------------
 
-NB! If you are using custom model managers **not** named `objects` and you expect them to still work, please read below.
+NB! If you are using custom model managers **not** named ``objects`` and you expect them to still work, please read below.
 
 Added
 ~~~~~
@@ -204,7 +204,7 @@ Changed
 - Changed auto conversion of currencies using djmoney_rates (added in 0.7.3) to
   be off by default. You must now add ``AUTO_CONVERT_MONEY = True`` in
   your ``settings.py`` if you want this feature. `#199`_ (`spookylukey`_)
-- Only make `objects` a MoneyManager instance automatically. `#194`_ and `#201`_ (`inureyes`_)
+- Only make ``objects`` a MoneyManager instance automatically. `#194`_ and `#201`_ (`inureyes`_)
 
 Fixed
 ~~~~~
@@ -439,7 +439,7 @@ Added
 - Initial public release
 
 .. _Unreleased: https://github.com/django-money/django-money/compare/0.13...HEAD
-.. _13.0: https://github.com/django-money/django-money/compare/0.12.3...13.0
+.. _0.13: https://github.com/django-money/django-money/compare/0.12.3..0.13
 .. _0.12.3: https://github.com/django-money/django-money/compare/0.12.2...0.12.3
 .. _0.12.2: https://github.com/django-money/django-money/compare/0.12.1...0.12.2
 .. _0.12.1: https://github.com/django-money/django-money/compare/0.12...0.12.1
@@ -541,7 +541,6 @@ Added
 .. _#86: https://github.com/django-money/django-money/issues/86
 .. _#80: https://github.com/django-money/django-money/issues/80
 
-.. _jonashaag: https://github.com/jonashaag
 .. _AlexRiina: https://github.com/AlexRiina
 .. _ChessSpider: https://github.com/ChessSpider
 .. _GheloAce: https://github.com/GheloAce

--- a/tests/contrib/exchange/test_model.py
+++ b/tests/contrib/exchange/test_model.py
@@ -47,7 +47,7 @@ def test_without_installed_exchange(testdir):
             'NAME': 'test.db',
         }
     }
-    INSTALLED_APPS = []
+    INSTALLED_APPS = ['djmoney']
     SECRET_KEY = 'foobar'
     ''')
     result = testdir.runpython_c(dedent('''

--- a/tests/contrib/exchange/test_model.py
+++ b/tests/contrib/exchange/test_model.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from textwrap import dedent
 
 from django.core.exceptions import ImproperlyConfigured
 
@@ -31,3 +32,31 @@ def test_bad_configuration(settings):
     settings.INSTALLED_APPS.remove('djmoney.contrib.exchange')
     with pytest.raises(ImproperlyConfigured):
         convert_money(Money(1, 'USD'), 'EUR')
+
+
+def test_without_installed_exchange(testdir):
+    """
+    If there is no 'djmoney.contrib.exchange' in INSTALLED_APPS importing `Money` should not cause a RuntimeError.
+    Details: GH-385.
+    """
+    testdir.mkpydir('money_app')
+    testdir.makepyfile(app_settings='''
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': 'test.db',
+        }
+    }
+    INSTALLED_APPS = []
+    SECRET_KEY = 'foobar'
+    ''')
+    result = testdir.runpython_c(dedent('''
+    import os
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'app_settings'
+    from django import setup
+
+    setup()
+    from djmoney.money import Money
+    print(Money(1, 'USD'))
+    '''))
+    result.stdout.fnmatch_lines(['US$1.00'])


### PR DESCRIPTION
It was possible to ``from djmoney.money import Money`` without  `djmoney.contrib.exchange` in INSTALLED_APPS