### PR TITLE
Rounding support via ``round`` built-in function on Python 3.

### DIFF
--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 import warnings
-from decimal import Decimal
 
 from django.conf import settings
 from django.db.models import F
@@ -76,8 +75,8 @@ class Money(DefaultMoney):
     def __html__(self):
         return mark_safe(avoid_wrapping(conditional_escape(self.__unicode__())))
 
-    def __round__(self, n=0):
-        amount = self.amount.quantize(Decimal(10) ** -n)
+    def __round__(self, n=None):
+        amount = round(self.amount, n)
         return self.__class__(amount, self.currency)
 
 

--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import warnings
+from decimal import Decimal
 
 from django.conf import settings
 from django.db.models import F
@@ -74,6 +75,10 @@ class Money(DefaultMoney):
 
     def __html__(self):
         return mark_safe(avoid_wrapping(conditional_escape(self.__unicode__())))
+
+    def __round__(self, n=0):
+        amount = self.amount.quantize(Decimal(10) ** -n)
+        return self.__class__(amount, self.currency)
 
 
 def get_current_locale():

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Added
+~~~~~
+
+- Rounding support via ``round`` built-in function on Python 3. (`Stranger6667`_)
+
 `0.13.1`_ - 2018-04-07
 --------------------
 

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -45,3 +45,11 @@ def test_default_truediv():
 def test_get_current_locale(locale, expected):
     with override(locale):
         assert get_current_locale() == expected
+
+
+@pytest.mark.skipif(
+    sys.version_info[0] == 2,
+    reason='round uses float on Python 2, which is a deprecated conversion for Money instances'
+)
+def test_round():
+    assert round(Money('1.69', 'USD'), 1) == Money('1.7', 'USD')


### PR DESCRIPTION
Hi @benjaoming !
Recently I found [this](https://stackoverflow.com/questions/49315079/how-to-round-up-django-money) question on StackOverflow. It could be a feature for ``django-money``.

With this patch, it will be possible to round ``Money`` instances with built-in ``round`` function:

```python
>>> value = Money('1.69', 'USD')
>>> round(value, 1)
<Money: 1.7 USD>
```

Unfortunately, there is no control for rounding on Python 2 - it will use deprecated ``__float__`` method :(

Could we use it like Python3-only feature?