### PR TITLE
Fix TypeError when decoding JSON in Python 3

### DIFF
--- a/djmoney/contrib/exchange/backends/base.py
+++ b/djmoney/contrib/exchange/backends/base.py
@@ -42,6 +42,8 @@ class BaseExchangeBackend(object):
         return response.read()
 
     def parse_json(self, response):
+        if isinstance(response, bytes):
+            response = response.decode('utf-8')
         return json.loads(response, parse_float=Decimal)
 
     @atomic


### PR DESCRIPTION
This pull request resolves `TypeError` when running with Python 3.

```
>>> from djmoney.contrib.exchange.models import get_rate
>>> OpenExchangeRatesBackend().update_rates()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python3.5/contextlib.py", line 30, in inner
    return func(*args, **kwds)
  File "/usr/local/lib/python3.5/site-packages/djmoney/contrib/exchange/backends/base.py", line 60, in update_rates
    for currency, value in self.get_rates(**params).items()
  File "/usr/local/lib/python3.5/site-packages/djmoney/contrib/exchange/backends/base.py", line 72, in get_rates
    return self.parse_json(response)['rates']
  File "/usr/local/lib/python3.5/site-packages/djmoney/contrib/exchange/backends/base.py", line 47, in parse_json
    return json.loads(response, parse_float=Decimal)
  File "/usr/local/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```