### PR TITLE
Fix illegal kwarg in test

### DIFF
--- a/tests/contrib/exchange/test_model.py
+++ b/tests/contrib/exchange/test_model.py
@@ -24,7 +24,7 @@ def test_get_rate(backend, source, target, expected):
 
 
 def test_unknown_currency():
-    with pytest.raises(MissingRate, matches='Rate USD -> EUR does not exist'):
+    with pytest.raises(MissingRate, match='Rate USD \\-\\> EUR does not exist'):
         get_rate('USD', 'EUR')
 
 


### PR DESCRIPTION
Hurray for PyTest fixing an issue that would cause a broken test to silently fail.

See: https://github.com/pytest-dev/pytest/issues/3348