### PR TITLE
Fix packaging

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,12 +6,15 @@ Changelog
 `0.14`_ - unreleased
 --------------------
 
+Fixed
+~~~~~
+
+- Packaging of ``djmoney.contrib.exchange.management.commands``. `#412`_ (`77cc33`_, `Stranger6667`_)
+
 Removed
 ~~~~~~~
 
 - Support for Python 3.3 `#410`_ (`benjaoming`_)
-
-
 
 `0.13.3`_ - 2018-05-12
 ----------------------
@@ -522,6 +525,8 @@ Added
 .. _0.3: https://github.com/django-money/django-money/compare/0.2...0.3
 .. _0.2: https://github.com/django-money/django-money/compare/0.2...a6d90348085332a393abb40b86b5dd9505489b04
 
+.. _#412: https://github.com/django-money/django-money/issues/412
+.. _#410: https://github.com/django-money/django-money/issues/410
 .. _#400: https://github.com/django-money/django-money/issues/400
 .. _#399: https://github.com/django-money/django-money/issues/399
 .. _#392: https://github.com/django-money/django-money/issues/392
@@ -592,6 +597,7 @@ Added
 .. _#86: https://github.com/django-money/django-money/issues/86
 .. _#80: https://github.com/django-money/django-money/issues/80
 
+.. _77cc33: https://github.com/77cc33
 .. _AlexRiina: https://github.com/AlexRiina
 .. _ChessSpider: https://github.com/ChessSpider
 .. _GheloAce: https://github.com/GheloAce

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
 
-from setuptools import setup
+from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 
 import djmoney
@@ -50,18 +50,7 @@ setup(
     url='https://github.com/django-money/django-money',
     maintainer='Greg Reinbach',
     maintainer_email='greg@reinbach.com',
-    packages=[
-        'djmoney',
-        'djmoney.forms',
-        'djmoney.models',
-        'djmoney.templatetags',
-        'djmoney.contrib',
-        'djmoney.contrib.django_rest_framework',
-        'djmoney.contrib.exchange',
-        'djmoney.contrib.exchange.backends',
-        'djmoney.contrib.exchange.management',
-        'djmoney.contrib.exchange.migrations',
-    ],
+    packages=find_packages(include=['djmoney.*']),
     install_requires=[
         'setuptools',
         'Django>=1.8',


### PR DESCRIPTION
Hi @benjaoming ! 

I didn't realize, that we dropped support for Python 3.3 in the `0.13.x` branch. To keep `0.13.x` branch without backward incompatible changes, could we restore it here and cherry-pick the commit to the master branch? Then we can release 0.13.4 bugfix release and continue with cleanup in master. 
Or something like:
- Fix packaging in `0.13.x`
- Merge `0.13.x` to master
- Restore support for Python 3.3 in `0.13.x`
- Release `0.13.4`

What do you think?

Kind Regards