### PR TITLE
Fix issue #418 of Same currency conversion

### DIFF
--- a/djmoney/contrib/exchange/models.py
+++ b/djmoney/contrib/exchange/models.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.utils.module_loading import import_string
 
+from djmoney._compat import text_type
 from djmoney.settings import EXCHANGE_BACKEND
 
 from .exceptions import MissingRate
@@ -50,7 +51,7 @@ def get_rate(source, target, backend=None):
     """
     if backend is None:
         backend = get_default_backend_name()
-    if source == target:
+    if text_type(source) == text_type(target):
         return 1
     try:
         forward = models.Q(currency=target, backend__base_currency=source)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,11 @@ Changelog
 `0.14`_ - unreleased
 --------------------
 
+Fixed
+~~~~~
+
+- Same currency conversion getting MissingRate exception `#418`_ (`humrochagf`_)
+
 Removed
 ~~~~~~~
 
@@ -613,6 +618,7 @@ Added
 .. _#90: https://github.com/django-money/django-money/issues/90
 .. _#86: https://github.com/django-money/django-money/issues/86
 .. _#80: https://github.com/django-money/django-money/issues/80
+.. _#418: https://github.com/django-money/django-money/issues/418
 
 .. _77cc33: https://github.com/77cc33
 .. _AlexRiina: https://github.com/AlexRiina
@@ -670,3 +676,4 @@ Added
 .. _w00kie: https://github.com/w00kie
 .. _willhcr: https://github.com/willhcr
 .. _1337: https://github.com/1337
+.. _humrochagf: https://github.com/humrochagf

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ test_requirements = [
     'pytest-django',
     'pytest-pythonpath',
     'pytest-cov',
+    'django-reversion',
 ]
 
 extras_requirements = {

--- a/tests/contrib/exchange/test_model.py
+++ b/tests/contrib/exchange/test_model.py
@@ -7,7 +7,7 @@ import pytest
 
 from djmoney.contrib.exchange.exceptions import MissingRate
 from djmoney.contrib.exchange.models import Rate, convert_money, get_rate
-from djmoney.money import Money
+from djmoney.money import Currency, Money
 
 
 pytestmark = pytest.mark.django_db
@@ -17,6 +17,8 @@ pytestmark = pytest.mark.django_db
     ('USD', 'USD', 1),
     ('USD', 'EUR', 2),
     ('EUR', 'USD', Decimal('0.5')),
+    (Currency('USD'), 'USD', 1),
+    ('USD', Currency('USD'), 1),
 ))
 def test_get_rate(backend, source, target, expected):
     Rate.objects.create(currency='EUR', value=2, backend=backend)


### PR DESCRIPTION
- Add django-reversion missing dependency for start testing at setup.py test_requirements
- Create tests for this issue
- Cast the currencies to its representation form that gets the currency code and ensure that they are the same