### PR TITLE
fix(ModelWithNullableCurrency): error was raised when trying to do a select

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -112,7 +112,7 @@ class MoneyFieldProxy(object):
         return data[self.field.name]
 
     def __set__(self, obj, value):  # noqa
-        if value is not None and self.field._currency_field.null and not isinstance(value, MONEY_CLASSES):
+        if value is not None and self.field._currency_field.null and not isinstance(value, MONEY_CLASSES + (Decimal,)):
             # For nullable fields we need either both NULL amount and currency or both NOT NULL
             raise ValueError('Missing currency value')
         if isinstance(value, BaseExpression):

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Fixed
+~~~~~
+
+- Error was raised when trying to do a query with a ModelWithNullableCurrency
+
+
 `0.14`_ - 2018-06-09
 --------------------
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -347,6 +347,18 @@ class TestNullableCurrency:
         assert str(exc.value) == 'Missing currency value'
         assert not ModelWithNullableCurrency.objects.exists()
 
+    def test_query_not_null(self):
+        money = Money(100, 'EUR')
+        ModelWithNullableCurrency.objects.create(money=money)
+        instance = ModelWithNullableCurrency.objects.get()
+        assert instance.money == money
+
+    def test_query_null(self):
+        ModelWithNullableCurrency.objects.create()
+        instance = ModelWithNullableCurrency.objects.get()
+        assert instance.money is None
+        assert instance.money_currency is None
+
 
 class TestFExpressions:
 


### PR DESCRIPTION
Hello everyone, I found this weird error, I also added a patch, but I would like someone to take a first look.

For the error observe the first test I've added:

```python
def test_no_fail_all(self):
    money = Money(100, 'EUR')
    instance = ModelWithNullableCurrency(money=money)
    instance.save()
    r = ModelWithNullableCurrency.objects.all()
    assert r[0].money == money
```
After doing that an error like this appears:

```python
~/projects/tmp/venv/lib/python3.6/site-packages/django/db/models/base.py in __init__(self, *args, **kwargs)
    500                 if val is _DEFERRED:
    501                     continue
--> 502                 _setattr(self, field.attname, val)
    503         else:
    504             # Slower, kwargs-ready version.

~/projects/tmp/venv/lib/python3.6/site-packages/djmoney/models/fields.py in __set__(self, obj, value)
    115         if value is not None and self.field._currency_field.null and not isinstance(value, MONEY_CLASSES):
    116             # For nullable fields we need either both NULL amount and currency or both NOT NULL
--> 117             raise ValueError('Missing currency value')
    118         if isinstance(value, BaseExpression):
    119             if isinstance(value, Value):

ValueError: Missing currency value
```

Steps to reproduce:
1. Create instance an assigned a Money value
2. Save instance
3. Do a Model.objects.all()
4. Observe "ValueError: Missing currency value"