### PR TITLE
Downgrade Tox to investigate possible regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - 3.6
 cache: pip
-install: travis_retry pip install tox codecov
+install: travis_retry pip install tox\<3.1 codecov
 script: tox -e $TOX_ENV
 matrix:
   fast_finish: true


### PR DESCRIPTION
Something broken in the way that dependencies are getting resolved, and I can't find an explanation in changes to our own code.

```
3.94s$ tox -e $TOX_ENV
django111-py34 create: /home/travis/build/django-money/django-money/.tox/django111-py34
django111-py34 installdeps: .[test], django-reversion==1.10.0, djangorestframework>=3.3.3,<3.7.0, Django>=1.11.0,<2.0.0, django-reversion>=2.0.8, djangorestframework>=3.6.2, django-reversion>=2.0.8, djangorestframework>=3.7.3, django-reversion>=2.0.8, djangorestframework>=3.6.2
ERROR: invocation failed (exit code 1), logfile: /home/travis/build/django-money/django-money/.tox/django111-py34/log/django111-py34-1.log
ERROR: actionid: django111-py34
msg: getenv
cmdargs: ['/home/travis/build/django-money/django-money/.tox/django111-py34/bin/pip', 'install', '.[test]', 'django-reversion==1.10.0', 'djangorestframework>=3.3.3,<3.7.0', 'Django>=1.11.0,<2.0.0', 'django-reversion>=2.0.8', 'djangorestframework>=3.6.2', 'django-reversion>=2.0.8', 'djangorestframework>=3.7.3', 'django-reversion>=2.0.8', 'djangorestframework>=3.6.2']
Double requirement given: django-reversion>=2.0.8 (already in django-reversion==1.10.0, name='django-reversion')
```