### PR TITLE
Re-raise arbitrary exceptions in JSON deserializer as `DeserializationError`

### DIFF
--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import sys
 
 from django.core.serializers.base import DeserializationError
 from django.core.serializers.json import Serializer as JSONSerializer
@@ -55,5 +56,7 @@ def Deserializer(stream_or_string, **options):  # noqa
                 for field, value in money_fields.items():
                     setattr(inner_obj.object, field, value)
                 yield inner_obj
-    except GeneratorExit:
+    except (GeneratorExit, DeserializationError):
         raise
+    except Exception as exc:
+        six.reraise(DeserializationError, DeserializationError(exc), sys.exc_info()[2])

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,11 @@ Changelog
 Unreleased
 ----------
 
+Changed
+~~~~~~~
+
+- Re-raise arbitrary exceptions in JSON deserializer as `DeserializationError`. (`Stranger6667`_)
+
 Fixed
 ~~~~~
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -73,3 +73,8 @@ def test_old_fields_skip(capsys, fixture_file):
     fixture_file.write(out)
     loaddata(fixture_file, True)
     assert ModelWithDefaultAsInt.objects.get().money == money
+
+
+def test_deserialization_error():
+    with pytest.raises(DeserializationError):
+        list(Deserializer("invalid JSON"))


### PR DESCRIPTION
To have the same behavior as it is in Django