### PR TITLE
Fixed InvalidOperation in djmoney.contrib.django_rest_framework.fields.MoneyField.get_value

### DIFF
--- a/djmoney/contrib/django_rest_framework/fields.py
+++ b/djmoney/contrib/django_rest_framework/fields.py
@@ -30,7 +30,7 @@ class MoneyField(DecimalField):
     def get_value(self, data):
         amount = super(MoneyField, self).get_value(data)
         currency = data.get(get_currency_field_name(self.field_name), None)
-        if currency:
+        if currency and amount is not None:
             return Money(amount, currency)
         return amount
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ Fixed
 ~~~~~
 
 - Invalid Django 1.8 version check in ``djmoney.models.fields.MoneyField.value_to_string``. (`Stranger6667`_)
+- InvalidOperation in ``djmoney.contrib.django_rest_framework.fields.MoneyField.get_value`` when amount is None and currency is not None. `#458`_ (`carvincarl`_)
 
 `0.14.3`_ - 2018-08-14
 ----------------------
@@ -602,6 +603,7 @@ Added
 .. _0.3: https://github.com/django-money/django-money/compare/0.2...0.3
 .. _0.2: https://github.com/django-money/django-money/compare/0.2...a6d90348085332a393abb40b86b5dd9505489b04
 
+.. _#458: https://github.com/django-money/django-money/issues/458
 .. _#443: https://github.com/django-money/django-money/issues/443
 .. _#439: https://github.com/django-money/django-money/issues/439
 .. _#427: https://github.com/django-money/django-money/pull/427
@@ -684,6 +686,7 @@ Added
 
 .. _77cc33: https://github.com/77cc33
 .. _AlexRiina: https://github.com/AlexRiina
+.. _carvincarl: https://github.com/carvincarl
 .. _ChessSpider: https://github.com/ChessSpider
 .. _GheloAce: https://github.com/GheloAce
 .. _Stranger6667: https://github.com/Stranger6667

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from decimal import Decimal
+
 import pytest
 
 from djmoney.money import Money
@@ -73,6 +75,9 @@ class TestMoneyField:
             ({'field': '10', 'field_currency': 'EUR'}, Money(10, 'EUR')),
             ({'field': '12.20', 'field_currency': 'GBP'}, Money(12.20, 'GBP')),
             ({'field': '15.15', 'field_currency': 'USD'}, Money(15.15, 'USD')),
+            ({'field': None, 'field_currency': None}, None),
+            ({'field': '16', 'field_currency': None}, Decimal('16.00')),
+            ({'field': None, 'field_currency': 'USD'}, None),
         ),
     )
     def test_post_put_values(self, body, expected):


### PR DESCRIPTION
Problem happens when amount is None and currency is not None.

Issue #458