### PR TITLE
Remove implicit default value

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -189,9 +189,6 @@ class MoneyField(models.DecimalField):
         Field.creation_counter += 1
 
     def setup_default(self, default, default_currency, nullable):
-        if default is None and not nullable:
-            # Backwards compatible fix for non-nullable fields
-            default = 0.0
         if isinstance(default, string_types):
             try:
                 # handle scenario where default is formatted like:
@@ -208,7 +205,7 @@ class MoneyField(models.DecimalField):
             default = Money(default, default_currency)
         elif isinstance(default, OldMoney):
             default.__class__ = Money
-        if not (nullable and default is None) and not isinstance(default, Money):
+        if default is not None and not isinstance(default, Money):
             raise ValueError('default value must be an instance of Money, is: %s' % default)
         return default
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,15 @@
 Changelog
 =========
 
+`Unreleased`_
+----------------------
+
+Changed
+~~~~~~~
+
+- Remove implicit default value on non-nullable MoneyFields.
+  Backwards incompatible change: set explicit ``default=0.0`` to keep previous behavior. `#411`_ (`washeck`_)
+
 `0.14.4`_ - 2019-01-07
 ----------------------
 
@@ -684,6 +693,7 @@ Added
 .. _#86: https://github.com/django-money/django-money/issues/86
 .. _#80: https://github.com/django-money/django-money/issues/80
 .. _#418: https://github.com/django-money/django-money/issues/418
+.. _#411: https://github.com/django-money/django-money/issues/411
 
 .. _77cc33: https://github.com/77cc33
 .. _AlexRiina: https://github.com/AlexRiina
@@ -746,3 +756,4 @@ Added
 .. _willhcr: https://github.com/willhcr
 .. _1337: https://github.com/1337
 .. _humrochagf: https://github.com/humrochagf
+.. _washeck: https://github.com/washeck

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -20,8 +20,8 @@ from .._compat import register
 
 
 class ModelWithVanillaMoneyField(models.Model):
-    money = MoneyField(max_digits=10, decimal_places=2)
-    second_money = MoneyField(max_digits=10, decimal_places=2, default_currency='EUR')
+    money = MoneyField(max_digits=10, decimal_places=2, default=0.0)
+    second_money = MoneyField(max_digits=10, decimal_places=2, default=0.0, default_currency='EUR')
     integer = models.IntegerField(default=0)
 
 
@@ -88,12 +88,12 @@ class ModelWithChoicesMoneyField(models.Model):
 
 
 class ModelWithNonMoneyField(models.Model):
-    money = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
+    money = MoneyField(max_digits=10, decimal_places=2, default=0.0, default_currency='USD')
     desc = models.CharField(max_length=10)
 
 
 class AbstractModel(models.Model):
-    money = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
+    money = MoneyField(max_digits=10, decimal_places=2, default=0.0, default_currency='USD')
     m2m_field = models.ManyToManyField(ModelWithDefaultAsInt)
 
     class Meta:
@@ -101,26 +101,26 @@ class AbstractModel(models.Model):
 
 
 class InheritorModel(AbstractModel):
-    second_field = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
+    second_field = MoneyField(max_digits=10, decimal_places=2, default=0.0, default_currency='USD')
 
 
 class RevisionedModel(models.Model):
-    amount = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
+    amount = MoneyField(max_digits=10, decimal_places=2, default=0.0, default_currency='USD')
 
 
 register(RevisionedModel)
 
 
 class BaseModel(models.Model):
-    money = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
+    money = MoneyField(max_digits=10, decimal_places=2, default=0.0, default_currency='USD')
 
 
 class InheritedModel(BaseModel):
-    second_field = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
+    second_field = MoneyField(max_digits=10, decimal_places=2, default=0.0, default_currency='USD')
 
 
 class SimpleModel(models.Model):
-    money = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
+    money = MoneyField(max_digits=10, decimal_places=2, default=0.0, default_currency='USD')
 
 
 class NullMoneyFieldModel(models.Model):


### PR DESCRIPTION
Since 189d8b65092a9e5b10c59e2b21a7a3dadfce4409 if no default
value is provided, value 0.0 and default currency is used.
This is opposite of what Django does and it makes it impossible
to specify not null fields with no default value.

Backwards incompatible change.