### PR TITLE
Fix model-level validators behavior in REST Framework

### DIFF
--- a/djmoney/contrib/django_rest_framework/fields.py
+++ b/djmoney/contrib/django_rest_framework/fields.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+from rest_framework.compat import MinValueValidator, MaxValueValidator
 from rest_framework.fields import empty
 from rest_framework.serializers import DecimalField, ModelSerializer
 
 from djmoney.models.fields import MoneyField as ModelField
+from djmoney.models.validators import MinMoneyValidator, MaxMoneyValidator
 from djmoney.money import Money
 from djmoney.utils import MONEY_CLASSES, get_currency_field_name
 
@@ -16,6 +18,15 @@ class MoneyField(DecimalField):
     def __init__(self, *args, **kwargs):
         self.default_currency = kwargs.pop('default_currency', None)
         super(MoneyField, self).__init__(*args, **kwargs)
+        # patches wrong validators for drf
+        validators = self.validators
+        print(type(validators))
+        for i in range(len(validators)):
+            if isinstance(validators[i], MinValueValidator):
+                validators[i] = MinMoneyValidator(self.min_value)
+            elif isinstance(validators[i], MaxValueValidator):
+                validators[i] = MaxMoneyValidator(self.max_value)
+        self.validators = validators
 
     def to_representation(self, obj):
         """

--- a/djmoney/models/validators.py
+++ b/djmoney/models/validators.py
@@ -2,11 +2,8 @@
 from decimal import Decimal
 
 from django.core.exceptions import ValidationError
-from django.core.validators import (
-    BaseValidator,
-    MaxValueValidator,
-    MinValueValidator,
-)
+from django.core.validators import BaseValidator
+from django.utils.translation import ugettext_lazy as _
 
 from djmoney.money import Money
 
@@ -38,9 +35,23 @@ class BaseMoneyValidator(BaseValidator):
             raise ValidationError(self.message, code=self.code, params=params)
 
 
-class MinMoneyValidator(BaseMoneyValidator, MinValueValidator):
-    pass
+# The validators below are not inherited from Django's validators because of
+# subclass check in Django REST Framework, that removes all validators
+# from the serializer field except the first one in the `validators` list of each validator type (min / max)
+# Removing inheritance is the simplest option to make model validators work in REST Framework
 
 
-class MaxMoneyValidator(BaseMoneyValidator, MaxValueValidator):
-    pass
+class MinMoneyValidator(BaseMoneyValidator):
+    message = _('Ensure this value is greater than or equal to %(limit_value)s.')
+    code = 'min_value'
+
+    def compare(self, a, b):
+        return a < b
+
+
+class MaxMoneyValidator(BaseMoneyValidator):
+    message = _('Ensure this value is less than or equal to %(limit_value)s.')
+    code = 'max_value'
+
+    def compare(self, a, b):
+        return a > b

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,8 @@ Backwards incompatible changes
 - Remove implicit default value on non-nullable MoneyFields.
   Backwards incompatible change: set explicit ``default=0.0`` to keep previous behavior. `#411`_ (`washeck`_)
 - Remove support for calling ``float`` on ``Money`` instances. Use the ``amount`` attribute instead. (`Stranger6667`_)
+- Model-level ``validators`` behavior in REST Framework. ``MinMoneyValidator`` and ``MaxMoneyValidator`` are
+  not inherited from Django's ``MinValueValidator`` and ``MaxValueValidator`` anymore. `#467`_ (`rapIsKal`_, `Stranger6667`_)
 
 Added
 ~~~~~
@@ -631,6 +633,7 @@ Added
 
 .. _#475: https://github.com/django-money/django-money/issues/475
 .. _#480: https://github.com/django-money/django-money/issues/480
+.. _#467: https://github.com/django-money/django-money/pull/467
 .. _#458: https://github.com/django-money/django-money/issues/458
 .. _#443: https://github.com/django-money/django-money/issues/443
 .. _#439: https://github.com/django-money/django-money/issues/439
@@ -764,6 +767,7 @@ Added
 .. _pjdelport: https://github.com/pjdelport
 .. _plumdog: https://github.com/plumdog
 .. _rach: https://github.com/rach
+.. _rapIsKal: https://github.com/rapIsKal
 .. _richardowen: https://github.com/richardowen
 .. _sjdines: https://github.com/sjdines
 .. _snbuchholz: https://github.com/snbuchholz


### PR DESCRIPTION
now if moneyfield is done with validator like MinMoneyValidator(1) attempt to make a crud through drf fails because MinMoneyValidator is treated by drf as MinValueValidator. This patch fixes problem