### PR TITLE
fix deserializer so _get_model monkey patching is possible

### DIFF
--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -4,10 +4,6 @@ import sys
 
 from django.core.serializers.base import DeserializationError
 from django.core.serializers.json import Serializer as JSONSerializer
-from django.core.serializers.python import (
-    Deserializer as PythonDeserializer,
-    _get_model,
-)
 from django.utils import six
 
 from djmoney.money import Money
@@ -23,6 +19,11 @@ def Deserializer(stream_or_string, **options):  # noqa
     """
     Deserialize a stream or string of JSON data.
     """
+    from django.core.serializers.python import (
+        Deserializer as PythonDeserializer,
+        _get_model,
+    )
+
     ignore = options.pop('ignorenonexistent', False)
 
     if not isinstance(stream_or_string, (bytes, six.string_types)):

--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -19,6 +19,8 @@ def Deserializer(stream_or_string, **options):  # noqa
     """
     Deserialize a stream or string of JSON data.
     """
+    # Local imports to allow using modified versions of `_get_model`
+    # It could be patched in runtime via `unittest.mock.patch` for example
     from django.core.serializers.python import (
         Deserializer as PythonDeserializer,
         _get_model,

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,12 @@ Fixed
 - Failing certificates checks when accessing 3rd party exchange rates backends.
   Fixed by adding `certifi` to the dependencies list. `#403`_ (`Stranger6667`_)
 
+Changed
+~~~~~~~
+
+- Allow using patched ``django.core.serializers.python._get_model`` in serializers, which could be helpful for
+  migrations. (`Formulka`_, `Stranger6667`_)
+
 `0.14.4`_ - 2019-01-07
 ----------------------
 
@@ -740,6 +746,7 @@ Added
 .. _eriktelepovsky: https://github.com/eriktelepovsky
 .. _evenicoulddoit: https://github.com/evenicoulddoit
 .. _f213: https://github.com/f213
+.. _Formulka: https://github.com/Formulka
 .. _glarrain: https://github.com/glarrain
 .. _graik: https://github.com/graik
 .. _gonzalobf: https://github.com/gonzalobf


### PR DESCRIPTION
Patching _get_model function is sometimes useful/necessary for migrations, good example is here: https://stackoverflow.com/a/5906258 if one needs to use a per-migration fixture. The import currently breaks this as it will always use the regular unpatched version of _get_model, simply moving it inside the Deserializer function fixes the issue.