### PR TITLE
Add support for customization `decimal_places` per `Money` instance

### DIFF
--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -22,6 +22,10 @@ class Money(DefaultMoney):
     """
     use_l10n = None
 
+    def __init__(self, *args, **kwargs):
+        self.decimal_places = kwargs.pop("decimal_places", DECIMAL_PLACES)
+        super(Money, self).__init__(*args, **kwargs)
+
     def __add__(self, other):
         if isinstance(other, F):
             return other.__radd__(self)
@@ -51,7 +55,7 @@ class Money(DefaultMoney):
         return self.use_l10n
 
     def __unicode__(self):
-        kwargs = {'money': self, 'decimal_places': DECIMAL_PLACES}
+        kwargs = {'money': self, 'decimal_places': self.decimal_places}
         if self.is_localized:
             locale = get_current_locale()
             if locale:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,11 @@ Backwards incompatible changes
   Backwards incompatible change: set explicit ``default=0.0`` to keep previous behavior. `#411`_ (`washeck`_)
 - Remove support for calling ``float`` on ``Money`` instances. Use the ``amount`` attribute instead. (`Stranger6667`_)
 
+Added
+~~~~~
+
+- Add ``Money.decimal_places`` for per-instance configuration of decimal places in the string representation.
+
 `0.14.4`_ - 2019-01-07
 ----------------------
 

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -49,3 +49,8 @@ def test_get_current_locale(locale, expected):
 )
 def test_round():
     assert round(Money('1.69', 'USD'), 1) == Money('1.7', 'USD')
+
+
+def test_configurable_decimal_number():
+    # Override default configuration per instance
+    assert str(Money('10.543', 'USD', decimal_places=3)) == '$10.543'


### PR DESCRIPTION
Hej @ZuluPro !

I added an alternative implementation for the feature you proposed, however, the chosen approach is the most simple and it doesn't allow this usage - `Money(10, 'USD', 3)`, only explicit keyword argument - `Money(10, 'USD', decimal_places=5)`

Keyword argument seems to me as a more clear approach, otherwise, it could be confusing what exactly does this 3rd number mean when somebody sees the code - `Money(10, 'USD', 3)`

Alternative implementations could be:
- Copy-pasting `__init__` signature from `py-moneyed`;
- introspection of the signature (which will add some complexity I'd like to avoid) during the module loading

Ref: #461 

