### PR TITLE
Support for customization of ``CurrencyField`` length. Closes #480

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -157,7 +157,7 @@ class CurrencyField(models.CharField):
     def __init__(self, price_field=None, default=DEFAULT_CURRENCY, **kwargs):
         if isinstance(default, Currency):
             default = default.code
-        kwargs['max_length'] = 3
+        kwargs.setdefault("max_length", 3)
         self.price_field = price_field
         super(CurrencyField, self).__init__(default=default, **kwargs)
 
@@ -174,12 +174,14 @@ class MoneyField(models.DecimalField):
                  default=None,
                  default_currency=DEFAULT_CURRENCY,
                  currency_choices=CURRENCY_CHOICES,
+                 currency_max_length=3,
                  currency_field_name=None, **kwargs):
         nullable = kwargs.get('null', False)
         default = self.setup_default(default, default_currency, nullable)
         if not default_currency and default is not None:
             default_currency = default.currency
 
+        self.currency_max_length = currency_max_length
         self.default_currency = default_currency
         self.currency_choices = currency_choices
         self.currency_field_name = currency_field_name
@@ -254,6 +256,7 @@ class MoneyField(models.DecimalField):
         """
         currency_field = CurrencyField(
             price_field=self,
+            max_length=self.currency_max_length,
             default=self.default_currency, editable=False,
             choices=self.currency_choices, null=self.default_currency is None
         )

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Added
 ~~~~~
 
 - Add ``Money.decimal_places`` for per-instance configuration of decimal places in the string representation.
+- Support for customization of ``CurrencyField`` length. Some cryptocurrencies could have codes longer than three characters. `#480`_ (`Stranger6667`_, `MrFus10n`_)
 
 `0.14.4`_ - 2019-01-07
 ----------------------
@@ -621,6 +622,7 @@ Added
 .. _0.3: https://github.com/django-money/django-money/compare/0.2...0.3
 .. _0.2: https://github.com/django-money/django-money/compare/0.2...a6d90348085332a393abb40b86b5dd9505489b04
 
+.. _#480: https://github.com/django-money/django-money/issues/480
 .. _#458: https://github.com/django-money/django-money/issues/458
 .. _#443: https://github.com/django-money/django-money/issues/443
 .. _#439: https://github.com/django-money/django-money/issues/439
@@ -746,6 +748,7 @@ Added
 .. _lobziik: https://github.com/lobziik
 .. _mattions: https://github.com/mattions
 .. _mithrilstar: https://github.com/mithrilstar
+.. _MrFus10n: https://github.com/MrFus10n
 .. _msgre: https://github.com/msgre
 .. _mstarostik: https://github.com/mstarostik
 .. _pjdelport: https://github.com/pjdelport

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -60,5 +60,7 @@ _FORMATTER.add_formatting_definition(
     rounding_method=ROUND_HALF_EVEN
 )
 
+moneyed.add_currency("USDT", "000", "Tether", None)
+
 OPEN_EXCHANGE_RATES_APP_ID = 'test'
 FIXER_ACCESS_KEY = 'test'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -24,6 +24,7 @@ from moneyed import Money as OldMoney
 from .testapp.models import (
     AbstractModel,
     BaseModel,
+    CryptoModel,
     DateTimeModel,
     InheritedModel,
     InheritorModel,
@@ -73,6 +74,7 @@ class TestVanillaMoneyField:
             (ModelWithDefaultAsString, {}, Money('123', 'PLN')),
             (ModelWithDefaultAsInt, {}, Money('123', 'GHS')),
             (ModelWithDefaultAsDecimal, {}, Money('0.01', 'CHF')),
+            (CryptoModel, {"money": Money(10, "USDT")}, Money(10, "USDT"))
         )
     )
     def test_create_defaults(self, model_class, kwargs, expected):

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -197,3 +197,7 @@ class ModelWithCustomDefaultManager(models.Model):
     if VERSION[:2] != (1, 8):
         class Meta:
             default_manager_name = 'custom'
+
+
+class CryptoModel(models.Model):
+    money = MoneyField(max_digits=10, decimal_places=2, currency_max_length=4)


### PR DESCRIPTION
Some cryptocurrencies could have codes longer than three characters