### PR TITLE
Remove default=None from deconstruct

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -295,7 +295,9 @@ class MoneyField(models.DecimalField):
     def deconstruct(self):
         name, path, args, kwargs = super(MoneyField, self).deconstruct()
 
-        if self.default is not None:
+        if self.default is None:
+            del kwargs['default']
+        else:
             kwargs['default'] = self.default.amount
         if self.default_currency != DEFAULT_CURRENCY:
             kwargs['default_currency'] = str(self.default_currency)


### PR DESCRIPTION
Deconstruct should include only kwargs which are different from
defaults. Without this fix, running makemigrations after #464
was merged results in AlterField operation with default=None
which is not needed as it is already the default value.