### PR TITLE
In model and non-model forms `forms.MoneyField` uses `CURRENCY_DECIMA…

### DIFF
--- a/djmoney/forms/fields.py
+++ b/djmoney/forms/fields.py
@@ -7,7 +7,7 @@ from django.forms import ChoiceField, DecimalField, MultiValueField
 from djmoney.money import Money
 from djmoney.utils import MONEY_CLASSES
 
-from ..settings import CURRENCY_CHOICES
+from ..settings import CURRENCY_CHOICES, DECIMAL_PLACES
 from .widgets import MoneyWidget
 
 
@@ -22,7 +22,7 @@ class MoneyField(MultiValueField):
         max_value=None,
         min_value=None,
         max_digits=None,
-        decimal_places=None,
+        decimal_places=DECIMAL_PLACES,
         default_amount=None,
         default_currency=None,
         *args,

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -17,7 +17,7 @@ from djmoney.money import Currency, Money
 from moneyed import Money as OldMoney
 
 from .._compat import MoneyValidator, setup_managers, smart_unicode, string_types
-from ..settings import CURRENCY_CHOICES, DEFAULT_CURRENCY
+from ..settings import CURRENCY_CHOICES, DECIMAL_PLACES, DEFAULT_CURRENCY
 from ..utils import MONEY_CLASSES, get_currency_field_name, prepare_expression
 
 
@@ -273,7 +273,7 @@ class MoneyField(models.DecimalField):
             return super(MoneyField, self).get_default()
 
     def formfield(self, **kwargs):
-        defaults = {"form_class": forms.MoneyField}
+        defaults = {"form_class": forms.MoneyField, "decimal_places": DECIMAL_PLACES}
         defaults.update(kwargs)
         defaults["currency_choices"] = self.currency_choices
         defaults["default_currency"] = self.default_currency

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ Backwards incompatible changes
   Backwards incompatible change: set explicit ``default=0.0`` to keep previous behavior. `#411`_ (`washeck`_)
 - Remove support for calling ``float`` on ``Money`` instances. Use the ``amount`` attribute instead. (`Stranger6667`_)
 - ``MinMoneyValidator`` and ``MaxMoneyValidator`` are not inherited from Django's ``MinValueValidator`` and ``MaxValueValidator`` anymore. `#376`_
+- In model and non-model forms ``forms.MoneyField`` uses ``CURRENCY_DECIMAL_PLACES`` as the default value for ``decimal_places``.`#434`_ (`Stranger6667`_, `andytwoods`_)
 
 Added
 ~~~~~
@@ -645,6 +646,7 @@ Added
 .. _#458: https://github.com/django-money/django-money/issues/458
 .. _#443: https://github.com/django-money/django-money/issues/443
 .. _#439: https://github.com/django-money/django-money/issues/439
+.. _#434: https://github.com/django-money/django-money/issues/434
 .. _#427: https://github.com/django-money/django-money/pull/427
 .. _#425: https://github.com/django-money/django-money/issues/425
 .. _#417: https://github.com/django-money/django-money/issues/417
@@ -738,6 +740,7 @@ Added
 .. _adi-: https://github.com/adi-
 .. _akumria: https://github.com/akumria
 .. _alexhayes: https://github.com/alexhayes
+.. _andytwoods: https://github.com/andytwoods
 .. _arthurk: https://github.com/arthurk
 .. _benjaoming: https://github.com/benjaoming
 .. _briankung: https://github.com/briankung

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -10,6 +10,7 @@ from django import VERSION
 
 import pytest
 
+from djmoney import settings
 from djmoney.models.fields import MoneyField
 from djmoney.money import Money
 
@@ -23,6 +24,8 @@ from .testapp.forms import (
     NullableModelForm,
     OptionalMoneyForm,
     PositiveValidatedMoneyModelForm,
+    PreciseForm,
+    PreciseModelForm,
     ValidatedMoneyModelForm,
 )
 from .testapp.models import ModelWithVanillaMoneyField, NullMoneyFieldModel
@@ -188,3 +191,10 @@ class TestDisabledField:
     def test_has_changed(self):
         form = DisabledFieldForm(data={})
         assert not form.has_changed()
+
+
+@pytest.mark.parametrize("model_class", (PreciseForm, PreciseModelForm))
+def test_decimal_places_model_form(model_class):
+    """Forms should use DECIMAL_PLACES setting value."""
+    expected = str(10 ** -settings.DECIMAL_PLACES)
+    assert model_class().fields["money"].widget.widgets[0].attrs["step"] == expected

--- a/tests/testapp/forms.py
+++ b/tests/testapp/forms.py
@@ -16,6 +16,7 @@ from .models import (
     ModelWithVanillaMoneyField,
     NullMoneyFieldModel,
     PositiveValidatedMoneyModel,
+    PreciseModel,
     SimpleModel,
     ValidatedMoneyModel,
 )
@@ -76,3 +77,16 @@ class DisabledFieldForm(forms.ModelForm):
     class Meta:
         fields = "__all__"
         model = SimpleModel
+
+
+class PreciseModelForm(forms.ModelForm):
+    class Meta:
+        fields = "__all__"
+        model = PreciseModel
+
+
+class PreciseForm(forms.Form):
+    money = MoneyField()
+
+    class Meta:
+        fields = "__all__"

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -190,3 +190,7 @@ class ModelWithCustomDefaultManager(models.Model):
 
 class CryptoModel(models.Model):
     money = MoneyField(max_digits=10, decimal_places=2, currency_max_length=4)
+
+
+class PreciseModel(models.Model):
+    money = MoneyField(max_digits=10, decimal_places=4)


### PR DESCRIPTION
…L_PLACES` as the default value for `decimal_places`. Closes #434