### PR TITLE
Drop support for old Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,6 @@ matrix:
     - python: pypy3
       env: TOX_ENV=django21-pypy3
     - python: 3.6
-      env: TOX_ENV=django20-py36
-    - python: 3.5
-      env: TOX_ENV=django20-py35
-    - python: 3.4
-      env: TOX_ENV=django20-py34
-    - python: pypy3
-      env: TOX_ENV=django20-pypy3
-    - python: 3.6
       env: TOX_ENV=django111-py36
     - python: 3.5
       env: TOX_ENV=django111-py35

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,5 @@ matrix:
       env: TOX_ENV=django111-py27
     - python: pypy2.7-5.8.0
       env: TOX_ENV=django111-pypy
-    - python: 3.5
-      env: TOX_ENV=django18-py35
-    - python: 3.4
-      env: TOX_ENV=django18-py34
-    - python: 2.7
-      env: TOX_ENV=django18-py27
-    - python: pypy2.7-5.8.0
-      env: TOX_ENV=django18-pypy
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ matrix:
       env: TOX_ENV=django111-py36
     - python: 3.5
       env: TOX_ENV=django111-py35
-    - python: 3.4
-      env: TOX_ENV=django111-py34
     - python: 2.7
       env: TOX_ENV=django111-py27
     - python: pypy2.7-5.8.0

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ http://code.google.com/p/python-money/
 
 This version adds tests, and comes with several critical bugfixes.
 
-Django versions supported: 1.8, 1.11, 2.0, 2.1, 2.2
+Django versions supported: 1.11, 2.0, 2.1, 2.2
 
 Python versions supported: 2.7, 3.4, 3.5, 3.6, 3.7
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ This version adds tests, and comes with several critical bugfixes.
 
 Django versions supported: 1.11, 2.1, 2.2
 
-Python versions supported: 2.7, 3.4, 3.5, 3.6, 3.7
+Python versions supported: 2.7, 3.5, 3.6, 3.7
 
 PyPy versions supported: PyPy 2.6, PyPy3 2.4
 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ http://code.google.com/p/python-money/
 
 This version adds tests, and comes with several critical bugfixes.
 
-Django versions supported: 1.11, 2.0, 2.1, 2.2
+Django versions supported: 1.11, 2.1, 2.2
 
 Python versions supported: 2.7, 3.4, 3.5, 3.6, 3.7
 

--- a/djmoney/_compat.py
+++ b/djmoney/_compat.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
-from django import VERSION
 
 
 try:
@@ -30,39 +29,10 @@ except ImportError:
     from urllib.request import urlopen
     from urllib.parse import urlparse, parse_qsl, urlunparse
 
-try:
-    from django.core.validators import DecimalValidator
-
-    class MoneyValidator(DecimalValidator):
-        def __call__(self, value):
-            return super(MoneyValidator, self).__call__(value.amount)
-
-
-except ImportError:
-    MoneyValidator = None
-
 
 def setup_managers(sender):
     from .models.managers import money_manager
 
-    if VERSION >= (1, 11):
-        default_manager_name = sender._meta.default_manager_name or "objects"
-        for manager in filter(lambda m: m.name == default_manager_name, sender._meta.local_managers):
-            money_manager(manager)
-    else:
-        sender.copy_managers(
-            [
-                (_id, name, money_manager(manager))
-                for _id, name, manager in sender._meta.concrete_managers
-                if name == "objects"
-            ]
-        )
-
-
-def get_success_style(style):
-    """
-    Django 1.8 has no `SUCCESS` style, but `MIGRATE_SUCCESS` is the same.
-    """
-    if VERSION[:2] == (1, 8):
-        return style.MIGRATE_SUCCESS
-    return style.SUCCESS
+    default_manager_name = sender._meta.default_manager_name or "objects"
+    for manager in filter(lambda m: m.name == default_manager_name, sender._meta.local_managers):
+        money_manager(manager)

--- a/djmoney/admin.py
+++ b/djmoney/admin.py
@@ -2,7 +2,6 @@
 import django.contrib.admin.helpers as admin_helpers
 import django.contrib.admin.templatetags.admin_list as admin_list
 import django.contrib.admin.utils as admin_utils
-from django import VERSION
 
 from ._compat import text_type
 from .models.fields import MoneyField
@@ -14,19 +13,10 @@ MODULES_TO_PATCH = [admin_utils, admin_helpers, admin_list]
 def setup_admin_integration():
     original_display_for_field = admin_utils.display_for_field
 
-    if VERSION[:2] == (1, 8):
-
-        def display_for_field(value, field):
-            if isinstance(field, MoneyField):
-                return text_type(value)
-            return original_display_for_field(value, field)
-
-    else:
-
-        def display_for_field(value, field, empty):
-            if isinstance(field, MoneyField):
-                return text_type(value)
-            return original_display_for_field(value, field, empty)
+    def display_for_field(value, field, empty):
+        if isinstance(field, MoneyField):
+            return text_type(value)
+        return original_display_for_field(value, field, empty)
 
     for mod in MODULES_TO_PATCH:
         setattr(mod, "display_for_field", display_for_field)

--- a/djmoney/contrib/exchange/management/base.py
+++ b/djmoney/contrib/exchange/management/base.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand
 
 from djmoney import settings
-from djmoney._compat import get_success_style
 
 
 class BaseExchangeCommand(BaseCommand):
@@ -22,5 +21,4 @@ class BaseExchangeCommand(BaseCommand):
         )
 
     def success(self, message):
-        style = get_success_style(self.style)
-        self.stdout.write(style(message))
+        self.stdout.write(self.style.SUCCESS(message))

--- a/djmoney/forms/fields.py
+++ b/djmoney/forms/fields.py
@@ -72,8 +72,7 @@ class MoneyField(MultiValueField):
         return super(MoneyField, self).clean(value)
 
     def has_changed(self, initial, data):  # noqa
-        # Django 1.8 has no 'disabled' attribute
-        if hasattr(self, "disabled") and self.disabled:
+        if self.disabled:
             return False
         if initial is None:
             initial = ["" for _ in range(0, len(data))]

--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -176,9 +176,6 @@ def _get_model(args, func):
     if hasattr(func, "__self__"):
         # Bound method
         model = func.__self__.model
-    elif hasattr(func, "__wrapped__"):
-        # Proxy model
-        model = func.__wrapped__.__self__.model
     else:
         # Custom method on user-defined model manager.
         model = args[0].model

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,8 +3,16 @@
 Changelog
 =========
 
+`1.0`_ - TBA
+------------
+
+Removed
+~~~~~~~
+
+- Support for Django 1.8 (`Stranger6667`_)
+
 `0.15`_ - 2019-05-30
-------------------------
+--------------------
 
 .. warning:: This release contains backwards incompatibility, please read the release notes below.
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,7 +9,7 @@ Changelog
 Removed
 ~~~~~~~
 
-- Support for Django 1.8 (`Stranger6667`_)
+- Support for Django 1.8 & 2.0 (`Stranger6667`_)
 
 `0.15`_ - 2019-05-30
 --------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Removed
 ~~~~~~~
 
 - Support for Django 1.8 & 2.0 (`Stranger6667`_)
+- Support for Python 3.4 (`Stranger6667`_)
 
 `0.15`_ - 2019-05-30
 --------------------

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     packages=find_packages(include=['djmoney', 'djmoney.*']),
     install_requires=[
         'setuptools',
-        'Django>=1.8',
+        'Django>=1.11',
         'py-moneyed>=0.8'
     ],
     platforms=['Any'],

--- a/tests/_compat.py
+++ b/tests/_compat.py
@@ -1,15 +1,6 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
-import reversion
 
-
-if reversion.VERSION >= (2, 0):
-    from reversion.revisions import create_revision, register
-    from reversion.models import Version
-
-    get_deleted = Version.objects.get_deleted
-else:
-    from reversion.revisions import get_deleted, create_revision, register
 try:
     from mock import patch, Mock
 except ImportError:

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from decimal import Decimal
 
+from django.utils import six
+
 import pytest
 
-import six
 from djmoney.money import Money
 
 from ..testapp.models import ModelWithVanillaMoneyField, NullMoneyFieldModel, ValidatedMoneyModel

--- a/tests/migrations/helpers.py
+++ b/tests/migrations/helpers.py
@@ -4,26 +4,19 @@ This module contains various helpers for migrations testing.
 """
 import os
 
-from django import VERSION
-
 
 MIGRATION_NAME = "test"
 
 
 def makemigrations():
     from django.core.management import call_command
-    from django.core.management.commands.makemigrations import Command
     from django.db.migrations import questioner
 
     # We should answer yes for all migrations questioner questions
     questioner.input = lambda x: "y"
 
     os.system("find . -name \*.pyc -delete")
-    if VERSION >= (1, 11):
-        call_command("makemigrations", "money_app", name=MIGRATION_NAME)
-    else:
-        # In Django 1.8 first argument name clashes with command option.
-        Command().execute("money_app", name=MIGRATION_NAME, verbosity=1)
+    call_command("makemigrations", "money_app", name=MIGRATION_NAME)
 
 
 def get_migration(name):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import django.contrib.admin.utils as admin_utils
-from django import VERSION
 
 import pytest
 
@@ -13,15 +12,6 @@ from .testapp.models import ModelWithVanillaMoneyField
 
 MONEY_FIELD = ModelWithVanillaMoneyField._meta.get_field("money")
 INTEGER_FIELD = ModelWithVanillaMoneyField._meta.get_field("integer")
-
-
-def get_args(value, field):
-    """
-    Constructs arguments for `display_for_field`.
-    """
-    if VERSION[:2] == (1, 8):
-        return value, field
-    return value, field, ""
 
 
 @pytest.mark.parametrize(
@@ -38,8 +28,8 @@ def test_display_for_field(settings, value, expected):
     settings.USE_L10N = True
     # This locale has no definitions in py-moneyed, so it will work for localized money representation.
     settings.LANGUAGE_CODE = "cs"
-    assert admin_utils.display_for_field(*get_args(value, MONEY_FIELD)) == expected
+    assert admin_utils.display_for_field(value, MONEY_FIELD, "") == expected
 
 
 def test_default_display():
-    assert admin_utils.display_for_field(*get_args(10, INTEGER_FIELD)) == "10"
+    assert admin_utils.display_for_field(10, INTEGER_FIELD, "") == "10"

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -6,8 +6,6 @@ Created on May 7, 2011
 """
 from decimal import Decimal
 
-from django import VERSION
-
 import pytest
 
 from djmoney import settings
@@ -108,11 +106,7 @@ def test_default_currency():
     """
     instance = NullMoneyFieldModel.objects.create()
     form = NullableModelForm(instance=instance)
-    if VERSION[:2] >= (1, 11):
-        expected = '<option value="USD" selected>US Dollar</option>'
-    else:
-        expected = '<option value="USD" selected="selected">US Dollar</option>'
-    assert expected in form.as_p()
+    assert '<option value="USD" selected>US Dollar</option>' in form.as_p()
 
 
 def test_fields_default_amount_becomes_forms_initial():
@@ -180,7 +174,6 @@ class TestValidation:
         assert form.errors == {"balance": [u"Ensure this value is greater than or equal to GB£100.00."]}
 
 
-@pytest.mark.skipif(VERSION[:2] == (1, 8), reason="Django 1.8 doesn't have `disabled` keyword in fields")
 class TestDisabledField:
     def test_validation(self):
         instance = ModelWithVanillaMoneyField.objects.create(money=Money("42.00", "USD"))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -179,7 +179,6 @@ class TestVanillaMoneyField:
     def test_comparison_lookup(self, filters, expected_count):
         assert ModelWithTwoMoneyFields.objects.filter(filters).count() == expected_count
 
-    @pytest.mark.skipif(VERSION[:2] == (1, 8), reason="Django 1.8 doesn't support __date lookup")
     def test_date_lookup(self):
         DateTimeModel.objects.create(field=Money(1, "USD"), created="2016-12-05")
         assert DateTimeModel.objects.filter(created__date="2016-12-01").count() == 0
@@ -470,7 +469,6 @@ class TestExpressions:
         assert ModelWithVanillaMoneyField.objects.get(integer=0).money == Money(10, "USD")
         assert ModelWithVanillaMoneyField.objects.get(integer=1).money == Money(0, "USD")
 
-    @pytest.mark.skipif(VERSION[:2] == (1, 8), reason="Django 1.8 doesn't supports this")
     def test_create_func(self):
         instance = ModelWithVanillaMoneyField.objects.create(money=Func(Value(-10), function="ABS"))
         instance.refresh_from_db()
@@ -586,12 +584,6 @@ def test_manager_instance_access(model_class):
         model_class().objects.all()
 
 
-@pytest.mark.skipif(VERSION[:2] != (1, 8), reason="Only Django 1.8 has `get_field_by_name` method of `Options`.")
-def test_get_field_by_name():
-    assert BaseModel._meta.get_field_by_name("money")[0].__class__.__name__ == "MoneyField"
-    assert BaseModel._meta.get_field_by_name("money_currency")[0].__class__.__name__ == "CurrencyField"
-
-
 def test_different_hashes():
     money = BaseModel._meta.get_field("money")
     money_currency = BaseModel._meta.get_field("money_currency")
@@ -613,8 +605,6 @@ def test_clear_meta_cache(model, manager_name):
     """
     See issue GH-318.
     """
-    if model is ModelWithCustomDefaultManager and VERSION[:2] == (1, 8):
-        pytest.skip("The `default_manager_name` setting is not available in Django 1.8")
     model._meta._expire_cache()
     manager_class = getattr(model, manager_name).__class__
     assert manager_class.__module__ + "." + manager_class.__name__ == "djmoney.models.managers.MoneyManager"

--- a/tests/test_reversion.py
+++ b/tests/test_reversion.py
@@ -2,8 +2,9 @@
 import pytest
 
 from djmoney.money import Money
+from reversion.models import Version
+from reversion.revisions import create_revision
 
-from ._compat import create_revision, get_deleted
 from .testapp.models import RevisionedModel
 
 
@@ -13,7 +14,7 @@ def test_that_can_safely_restore_deleted_object():
     with create_revision():
         instance = RevisionedModel.objects.create(amount=amount)
     instance.delete()
-    version = get_deleted(RevisionedModel)[0]
+    version = Version.objects.get_deleted(RevisionedModel)[0]
     version.revision.revert()
     instance = RevisionedModel.objects.get(pk=1)
     assert instance.amount == amount

--- a/tests/testapp/forms.py
+++ b/tests/testapp/forms.py
@@ -6,7 +6,7 @@ Created on May 15, 2011
 """
 from __future__ import unicode_literals
 
-from django import VERSION, forms
+from django import forms
 
 from djmoney.forms import MoneyField
 
@@ -71,8 +71,7 @@ class PositiveValidatedMoneyModelForm(forms.ModelForm):
 
 
 class DisabledFieldForm(forms.ModelForm):
-    if VERSION[:2] != (1, 8):
-        money = MoneyField(disabled=True)
+    money = MoneyField(disabled=True)
 
     class Meta:
         fields = "__all__"

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -6,7 +6,6 @@ Created on May 7, 2011
 """
 from decimal import Decimal
 
-from django import VERSION
 from django.core.validators import MinValueValidator
 from django.db import models
 
@@ -15,8 +14,7 @@ from djmoney.models.managers import money_manager, understands_money
 from djmoney.models.validators import MaxMoneyValidator, MinMoneyValidator
 from djmoney.money import Money
 from moneyed import Money as OldMoney
-
-from .._compat import register
+from reversion.revisions import register
 
 
 class ModelWithVanillaMoneyField(models.Model):
@@ -182,10 +180,8 @@ class ModelWithCustomDefaultManager(models.Model):
 
     custom = models.Manager()
 
-    if VERSION[:2] != (1, 8):
-
-        class Meta:
-            default_manager_name = "custom"
+    class Meta:
+        default_manager_name = "custom"
 
 
 class CryptoModel(models.Model):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     django_master-py{37,36}
     django22-py{37,36}
     django21-py{37,36,35,py3}
-    django111-py{36,35,34,27,py}
+    django111-py{36,35,27,py}
     lint
     docs
 skipsdist = true

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist =
     django_master-py{37,36}
     django22-py{37,36}
     django21-py{37,36,35,py3}
-    django20-py{36,35,34,py3}
     django111-py{36,35,34,27,py}
     lint
     docs
@@ -17,7 +16,6 @@ python_paths = {toxinidir}
 deps =
     .[test,exchange]
     django111: {[django]1.11.x}
-    django20: {[django]2.0.x}
     django21: {[django]2.1.x}
     django22: {[django]2.2.x}
     django_master: {[django]master}
@@ -47,10 +45,6 @@ commands =
        Django>=1.11.0,<2.0.0
        django-reversion>=2.0.8
        djangorestframework>=3.6.2
-2.0.x  =
-       Django>=2.0,<2.1
-       django-reversion>=2.0.8
-       djangorestframework>=3.7.3
 2.1.x  =
        Django>=2.1,<2.2
        django-reversion>=2.0.8

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist =
     django21-py{37,36,35,py3}
     django20-py{36,35,34,py3}
     django111-py{36,35,34,27,py}
-    django18-py{35,34,27,py}
     lint
     docs
 skipsdist = true
@@ -17,7 +16,6 @@ python_paths = {toxinidir}
 [testenv]
 deps =
     .[test,exchange]
-    django18: {[django]1.8.x}
     django111: {[django]1.11.x}
     django20: {[django]2.0.x}
     django21: {[django]2.1.x}
@@ -45,10 +43,6 @@ commands =
     black -l 120 {toxinidir}/djmoney {toxinidir}/tests
 
 [django]
-1.8.x  =
-       Django>=1.8.0,<1.9.0
-       django-reversion==1.10.0
-       djangorestframework>=3.3.3,<3.7.0
 1.11.x  =
        Django>=1.11.0,<2.0.0
        django-reversion>=2.0.8


### PR DESCRIPTION
Mb we should also remove Python 3.4 from the build matrix since it is not supported anymore ... 