### PR TITLE
Getting a Money object with decimal places from a MoneyField

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -93,7 +93,7 @@ class MoneyFieldProxy(object):
         currency = obj.__dict__[self.currency_field_name]
         if amount is None:
             return None
-        return Money(amount=amount, currency=currency)
+        return Money(amount=amount, currency=currency, decimal_places=self.field.decimal_places)
 
     def __get__(self, obj, type=None):
         if obj is None:


### PR DESCRIPTION
Right now when getting a MoneyField it returns a Money object without the MoneyField decimal places, producing unexpected behaviour when printing/converting to a string. I'm not sure if that works as I don't have the time to test so consider this as an issue with a probable pull request. It's my first pull request so sorry about anything, and have a nice day :)

![image](https://user-images.githubusercontent.com/15985195/59732963-0e0f0a00-9201-11e9-812e-635fde650d7e.png)
