### PR TITLE
Fixed currency_widget handling.

### DIFF
--- a/djmoney/forms/fields.py
+++ b/djmoney/forms/fields.py
@@ -36,17 +36,11 @@ class MoneyField(MultiValueField):
         )
         currency_field = ChoiceField(choices=currency_choices)
 
-        # TODO: No idea what currency_widget is supposed to do since it doesn't
-        # even receive currency choices as input. Somehow it's supposed to be
-        # instantiated from outside. Hard to tell.
-        if currency_widget:
-            self.widget = currency_widget
-        else:
-            self.widget = MoneyWidget(
-                amount_widget=amount_field.widget,
-                currency_widget=currency_field.widget,
-                default_currency=default_currency,
-            )
+        self.widget = MoneyWidget(
+            amount_widget=amount_field.widget,
+            currency_widget=currency_widget or currency_field.widget,
+            default_currency=default_currency,
+        )
         # The two fields that this widget comprises
         fields = (amount_field, currency_field)
         super(MoneyField, self).__init__(fields, *args, **kwargs)


### PR DESCRIPTION
I've made a small fix: the currency_widget parameter of forms.fields.MoneyField.__init__ was handled incorrectly when passed in a (non-None) value. It got assigned to the self.widget (i.e. used as the widget for the MoneyField) istead of the being used as the currency widget of the MoneyWidget.