### PR TITLE
Fix order_by() not being wrapped by understand_money() 

### DIFF
--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -206,7 +206,7 @@ def understands_money(func):
     return wrapper
 
 
-RELEVANT_QUERYSET_METHODS = ("distinct", "get", "get_or_create", "filter", "exclude", "update")
+RELEVANT_QUERYSET_METHODS = ("distinct", "get", "get_or_create", "filter", "exclude", "update", "order_by")
 EXPAND_EXCLUSIONS = {"get_or_create": ("defaults",)}
 
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,7 +10,7 @@ Added
 ~~~~~
 
 - Support for money descriptor customization. (`Stranger6667`_)
-- Fix `order_by()` not returning money-compatible queryset `#519`_
+- Fix `order_by()` not returning money-compatible queryset `#519`_ (`lieryan`_)
 - Django 3.0 support
 
 Removed
@@ -760,6 +760,7 @@ Added
 .. _#80: https://github.com/django-money/django-money/issues/80
 .. _#418: https://github.com/django-money/django-money/issues/418
 .. _#411: https://github.com/django-money/django-money/issues/411
+.. _#519: https://github.com/django-money/django-money/issues/519
 
 .. _77cc33: https://github.com/77cc33
 .. _AlexRiina: https://github.com/AlexRiina
@@ -804,6 +805,7 @@ Added
 .. _ivirabyan: https://github.com/ivirabyan
 .. _k8n: https://github.com/k8n
 .. _lmdsp: https://github.com/lmdsp
+.. _lieryan: https://github.com/lieryan
 .. _lobziik: https://github.com/lobziik
 .. _mattions: https://github.com/mattions
 .. _mithrilstar: https://github.com/mithrilstar

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Added
 ~~~~~
 
 - Support for money descriptor customization. (`Stranger6667`_)
+- Fix `order_by()` not returning money-compatible queryset `#519`_
 - Django 3.0 support
 
 Removed

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -697,3 +697,14 @@ class TestSharedCurrency:
         instance = ModelWithSharedCurrency.objects.create(first=value, second=value)
         assert instance.first == value
         assert instance.second == value
+
+def test_order_by():
+    def extract_data(instance):
+        return instance.money, instance.integer
+
+    instance1 = ModelWithVanillaMoneyField.objects.create(money=Money(10, 'AUD'), integer=2)
+    instance2 = ModelWithVanillaMoneyField.objects.create(money=Money(10, 'AUD'), integer=1)
+    instance3 = ModelWithVanillaMoneyField.objects.create(money=Money(10, 'USD'), integer=3)
+
+    qs = ModelWithVanillaMoneyField.objects.order_by('integer').filter(money=Money(10, 'AUD'))
+    assert list(map(extract_data, qs)) == [(Money(10, 'AUD'), 1), (Money(10, 'AUD'), 2)]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -702,9 +702,9 @@ def test_order_by():
     def extract_data(instance):
         return instance.money, instance.integer
 
-    instance1 = ModelWithVanillaMoneyField.objects.create(money=Money(10, 'AUD'), integer=2)
-    instance2 = ModelWithVanillaMoneyField.objects.create(money=Money(10, 'AUD'), integer=1)
-    instance3 = ModelWithVanillaMoneyField.objects.create(money=Money(10, 'USD'), integer=3)
+    ModelWithVanillaMoneyField.objects.create(money=Money(10, 'AUD'), integer=2)
+    ModelWithVanillaMoneyField.objects.create(money=Money(10, 'AUD'), integer=1)
+    ModelWithVanillaMoneyField.objects.create(money=Money(10, 'USD'), integer=3)
 
     qs = ModelWithVanillaMoneyField.objects.order_by('integer').filter(money=Money(10, 'AUD'))
     assert list(map(extract_data, qs)) == [(Money(10, 'AUD'), 1), (Money(10, 'AUD'), 2)]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -698,13 +698,14 @@ class TestSharedCurrency:
         assert instance.first == value
         assert instance.second == value
 
+
 def test_order_by():
     def extract_data(instance):
         return instance.money, instance.integer
 
-    ModelWithVanillaMoneyField.objects.create(money=Money(10, 'AUD'), integer=2)
-    ModelWithVanillaMoneyField.objects.create(money=Money(10, 'AUD'), integer=1)
-    ModelWithVanillaMoneyField.objects.create(money=Money(10, 'USD'), integer=3)
+    ModelWithVanillaMoneyField.objects.create(money=Money(10, "AUD"), integer=2)
+    ModelWithVanillaMoneyField.objects.create(money=Money(10, "AUD"), integer=1)
+    ModelWithVanillaMoneyField.objects.create(money=Money(10, "USD"), integer=3)
 
-    qs = ModelWithVanillaMoneyField.objects.order_by('integer').filter(money=Money(10, 'AUD'))
-    assert list(map(extract_data, qs)) == [(Money(10, 'AUD'), 1), (Money(10, 'AUD'), 2)]
+    qs = ModelWithVanillaMoneyField.objects.order_by("integer").filter(money=Money(10, "AUD"))
+    assert list(map(extract_data, qs)) == [(Money(10, "AUD"), 1), (Money(10, "AUD"), 2)]


### PR DESCRIPTION
This is probably related to https://github.com/django-money/django-money/issues/99, but
money_manager didn't work correctly with order_by. This fails with both custom
money_manager() and the automatically generated manager.

# Minimal test case

## tests.py
   
    from django.test import TestCase
   
    from djmoney.money import Money
    from chaining.models import Question
   
   
    class QuestionTest(TestCase):
        def test_prize(self):
            question_aud = Question.objects.create(prize=Money(10, 'AUD'))
            question_usd = Question.objects.create(prize=Money(10, 'USD'))
   
            # passes as expected
            self.assertQuerysetEqual(
                Question.objects.filter(prize=Money(10, 'AUD')),
                ['<Question: Q#1 - A$10.00>'],
            )
   
            # however, order_by didn't work correctly
            self.assertQuerysetEqual(
                Question.objects.order_by('id').filter(prize=Money(10, 'AUD')),
                ['<Question: Q#1 - A$10.00>'],
                # actual value: ['<Question: Q#1 - A$10.00>', '<Question: Q#2 - $10.00>']
            )


## models.py

    from django.db import models
    from djmoney.models.fields import MoneyField
   
   
    class Question(models.Model):
        prize = MoneyField(decimal_places=2, max_digits=10)
   
        def __str__(self):
            return 'Q#{} - {}'.format(self.pk, self.prize)