### PR TITLE
Replace `smart_text` with `smart_str`

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.db.models import F, Field, Func, Value
 from django.db.models.expressions import BaseExpression
 from django.db.models.signals import class_prepared
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.utils.functional import cached_property
 
 from djmoney import forms
@@ -76,7 +76,7 @@ def get_currency(value):
     Extracts currency from value.
     """
     if isinstance(value, MONEY_CLASSES):
-        return smart_text(value.currency)
+        return smart_str(value.currency)
     elif isinstance(value, (list, tuple)):
         return value[1]
 

--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -4,7 +4,7 @@ from django.db.models import Case, F, Q
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import BaseExpression
 from django.db.models.fields import FieldDoesNotExist
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from ..utils import MONEY_CLASSES, get_currency_field_name, prepare_expression
 from .fields import CurrencyField, MoneyField
@@ -98,7 +98,7 @@ def _expand_arg(model, arg):
             if isinstance(value, MONEY_CLASSES):
                 clean_name = _get_clean_name(model, name)
                 currency_field_name = get_currency_field_name(clean_name, field)
-                arg.children[i] = Q(child, (currency_field_name, smart_text(value.currency)))
+                arg.children[i] = Q(child, (currency_field_name, smart_str(value.currency)))
             if isinstance(field, MoneyField):
                 if isinstance(value, (BaseExpression, F)):
                     clean_name = _get_clean_name(model, name)
@@ -138,7 +138,7 @@ def _expand_money_kwargs(model, args=(), kwargs=None, exclusions=()):
             clean_name = _get_clean_name(model, name)
             kwargs[name] = value.amount
             currency_field_name = get_currency_field_name(clean_name, field)
-            kwargs[currency_field_name] = smart_text(value.currency)
+            kwargs[currency_field_name] = smart_str(value.currency)
         else:
             if isinstance(field, MoneyField):
                 if isinstance(value, (BaseExpression, F)) and not isinstance(value, Case):


### PR DESCRIPTION
In Django 3.0b1 I get `RemovedInDjango40Warning: smart_text() is deprecated in favor of smart_str().` so I’ve replaced `smart_text` with `smart_str`.