### PR TITLE
WIP: Fix #530 -- Keep None as `default_currency` in `deconstruct()`

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -294,6 +294,8 @@ class MoneyField(models.DecimalField):
             del kwargs["default"]
         else:
             kwargs["default"] = self.default.amount
+        if self.default_currency is None:  # None needs to be preserved
+            kwargs["default_currency"] = self.default_currency
         if self.default_currency is not None and self.default_currency != DEFAULT_CURRENCY:
             kwargs["default_currency"] = str(self.default_currency)
         if self.currency_choices != CURRENCY_CHOICES:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,15 @@
 Changelog
 =========
 
+`1.1.dev`_ - (unreleased)
+-------------------------
+
+Fixed
+~~~~~
+
+- Fix ``default_currency=None`` not making ``CurrencyField`` nullable in SQL migrations `#530`_ (`jrocketfingers`_)
+
+
 `1.0`_ - 2019-11-08
 -------------------
 


### PR DESCRIPTION
When setting `default_currency=None` django migrations would
erroneously make the `CurrencyField` non-nullable. This is because
Django's `Field.clone()` uses `deconstruct()` to clone the field
during migrations. Since `None` is actually user set (and can differ
from the default), we need to explicitly add it to kwargs.

Fixes #530.