### PR TITLE
Import FieldDoesNotExist exception from current location

### DIFF
--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -1,9 +1,9 @@
 from functools import wraps
 
+from django.core.exceptions import FieldDoesNotExist
 from django.db.models import Case, F, Q
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import BaseExpression
-from django.db.models.fields import FieldDoesNotExist
 from django.utils.encoding import smart_str
 
 from ..utils import MONEY_CLASSES, get_currency_field_name, prepare_expression


### PR DESCRIPTION
The backwards-compatibility import from django.db.models.fields will be
removed in django 3.1.
See https://github.com/django/django/commit/129583a0d3cf69b08d058cd751d777588801b7ad#diff-bf776a3b8e5dbfac2432015825ef8afeL15-L18