### PR TITLE
Optimize money operations on moneys with the same currencies

### DIFF
--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -90,7 +90,7 @@ def maybe_convert(value, currency):
     """
     Converts other Money instances to the local currency if `AUTO_CONVERT_MONEY` is set to True.
     """
-    if getattr(settings, "AUTO_CONVERT_MONEY", False):
+    if getattr(settings, "AUTO_CONVERT_MONEY", False) and value.currency != currency:
         from .contrib.exchange.models import convert_money
 
         return convert_money(value, currency)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,11 @@ Changelog
 
 `1.1`_ - TBA
 
+Fixed
+~~~~~
+
+- Optimize money operations on monies with the same currencies. (`horpto`)
+
 Added
 ~~~~~
 


### PR DESCRIPTION
if AUTO_CONVERT_MONEY is enabled many operations will be slower. It's ok for values with different currencies. But for the same currencies it's quite strange and unjustifiably (check on performance comparison).

```
from djmoney.money import Money
from time import perf_counter

m = Money('0', 'RUB')
s = Money('1', 'RUB')

t0 = perf_counter()
for i in range(1000):
    m += s

print(perf_counter() - t0)  # 0.5836477298289537

m = Money('0', 'RUB')

t0 = perf_counter()
for i in range(1000):
    m.amount += s.amount

print(perf_counter() - t0)  # 0.0011850465089082718
```