### PR TITLE
fix: inherit decimal places from arguments in arithmetic operations #522

### DIFF
--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -26,27 +26,40 @@ class Money(DefaultMoney):
         self.decimal_places = kwargs.pop("decimal_places", DECIMAL_PLACES)
         super().__init__(*args, **kwargs)
 
+    def _fix_decimal_places(self, *args):
+        """ Make sure to user 'biggest' number of decimal places of all given money instances """
+        candidates = (getattr(candidate, "decimal_places", 0) for candidate in args)
+        return max([self.decimal_places, *candidates])
+
     def __add__(self, other):
         if isinstance(other, F):
             return other.__radd__(self)
         other = maybe_convert(other, self.currency)
-        return super().__add__(other)
+        result = super().__add__(other)
+        result.decimal_places = self._fix_decimal_places(other)
+        return result
 
     def __sub__(self, other):
         if isinstance(other, F):
             return other.__rsub__(self)
         other = maybe_convert(other, self.currency)
-        return super().__sub__(other)
+        result = super().__sub__(other)
+        result.decimal_places = self._fix_decimal_places(other)
+        return result
 
     def __mul__(self, other):
         if isinstance(other, F):
             return other.__rmul__(self)
-        return super().__mul__(other)
+        result = super().__mul__(other)
+        result.decimal_places = self._fix_decimal_places(other)
+        return result
 
     def __truediv__(self, other):
         if isinstance(other, F):
             return other.__rtruediv__(self)
-        return super().__truediv__(other)
+        result = super().__truediv__(other)
+        result.decimal_places = self._fix_decimal_places(other)
+        return result
 
     @property
     def is_localized(self):
@@ -69,6 +82,14 @@ class Money(DefaultMoney):
     def __round__(self, n=None):
         amount = round(self.amount, n)
         return self.__class__(amount, self.currency)
+
+    # DefaultMoney sets those synonym functions
+    # we overwrite the 'targets' so the wrong synonyms are called
+    # Example: we overwrite __add__; __radd__ calls __add__ on DefaultMoney...
+    __radd__ = __add__
+    __rsub__ = __sub__
+    __rmul__ = __mul__
+    __rtruediv__ = __truediv__
 
 
 def get_current_locale():

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,15 @@
 Changelog
 =========
 
+`1.2`_ - TBA
+------------
+
+Fixed
+~~~~~
+
+- Resulting Money object from arithmetics (add / sub / ...) inherits maximum decimal_places from arguments `522` (`wearebasti`)
+
+
 `1.1`_ - 2020-04-06
 -------------------
 

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -42,3 +42,45 @@ def test_round():
 def test_configurable_decimal_number():
     # Override default configuration per instance
     assert str(Money("10.543", "USD", decimal_places=3)) == "$10.543"
+
+
+def test_add_decimal_places():
+    one = Money(1.0000, "USD", decimal_places=4)
+    two = Money(2.000000005, "USD", decimal_places=10)
+
+    result = one + two
+    assert result.decimal_places == 10
+
+
+def test_add_decimal_places_zero():
+    two = Money(2.005, "USD", decimal_places=3)
+
+    result = two + 0
+    assert result.decimal_places == 3
+
+
+def test_mul_decimal_places():
+    """ Test __mul__ and __rmul__ """
+    two = Money(1.0000, "USD", decimal_places=4)
+
+    result = 2 * two
+    assert result.decimal_places == 4
+
+    result = two * 2
+    assert result.decimal_places == 4
+
+
+def test_fix_decimal_places():
+    one = Money(1, "USD", decimal_places=7)
+    assert one._fix_decimal_places(Money(2, "USD", decimal_places=3)) == 7
+    assert one._fix_decimal_places(Money(2, "USD", decimal_places=30)) == 30
+
+
+def test_fix_decimal_places_none():
+    one = Money(1, "USD", decimal_places=7)
+    assert one._fix_decimal_places(None) == 7
+
+
+def test_fix_decimal_places_multiple():
+    one = Money(1, "USD", decimal_places=7)
+    assert one._fix_decimal_places(None, Money(3, "USD", decimal_places=8)) == 8


### PR DESCRIPTION
This is supposed to resolve #522 

The `DefaultMoney` creates new `DefaultMoney`-Objects in the operations and returns those. These are initialized with the default decimal_places instead of the ones from the given operators.

To make sure to not "cut" decimal_places the 'biggest' one is taken into account.

I am not a big fan of the code duplication I introduced but I didn't see a nicer way (for now).

Added the explicit linking of `__ruml__` to `__mul__` as they are set like this in the `DefaultMoney` class but not in `Money` leading to inconsistent behaviour (a*b != b*a)
