### PR TITLE
set default to NOT_PROVIDED

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from django.core.exceptions import ValidationError
 from django.core.validators import DecimalValidator
 from django.db import models
-from django.db.models import F, Field, Func, Value
+from django.db.models import NOT_PROVIDED, F, Field, Func, Value
 from django.db.models.expressions import BaseExpression
 from django.db.models.signals import class_prepared
 from django.utils.encoding import smart_str
@@ -167,7 +167,7 @@ class MoneyField(models.DecimalField):
         name=None,
         max_digits=None,
         decimal_places=DECIMAL_PLACES,
-        default=None,
+        default=NOT_PROVIDED,
         default_currency=DEFAULT_CURRENCY,
         currency_choices=CURRENCY_CHOICES,
         currency_max_length=3,
@@ -177,7 +177,7 @@ class MoneyField(models.DecimalField):
     ):
         nullable = kwargs.get("null", False)
         default = self.setup_default(default, default_currency, nullable)
-        if not default_currency and default is not None:
+        if not default_currency and default is not NOT_PROVIDED:
             default_currency = default.currency
 
         self.currency_max_length = currency_max_length
@@ -207,7 +207,7 @@ class MoneyField(models.DecimalField):
             default = Money(default, default_currency)
         elif isinstance(default, OldMoney):
             default.__class__ = Money
-        if default is not None and not isinstance(default, Money):
+        if default is not None and default is not NOT_PROVIDED and not isinstance(default, Money):
             raise ValueError("default value must be an instance of Money, is: %s" % default)
         return default
 
@@ -279,7 +279,7 @@ class MoneyField(models.DecimalField):
         defaults.update(kwargs)
         defaults["currency_choices"] = self.currency_choices
         defaults["default_currency"] = self.default_currency
-        if self.default is not None:
+        if self.default is not None and self.default is not NOT_PROVIDED:
             defaults["default_amount"] = self.default.amount
         return super().formfield(**defaults)
 
@@ -290,8 +290,8 @@ class MoneyField(models.DecimalField):
     def deconstruct(self):
         name, path, args, kwargs = super().deconstruct()
 
-        if self.default is None:
-            del kwargs["default"]
+        if self.default is NOT_PROVIDED:
+            pass
         else:
             kwargs["default"] = self.default.amount
         if self.default_currency is not None and self.default_currency != DEFAULT_CURRENCY:

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -290,7 +290,7 @@ class MoneyField(models.DecimalField):
     def deconstruct(self):
         name, path, args, kwargs = super().deconstruct()
 
-        if self.default is NOT_PROVIDED:
+        if self.default in [None, NOT_PROVIDED]:
             pass
         else:
             kwargs["default"] = self.default.amount

--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 from django.core.exceptions import FieldDoesNotExist
-from django.db.models import Case, F, Q
+from django.db.models import NOT_PROVIDED, Case, F, Q
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import BaseExpression
 from django.db.models.functions import Cast
@@ -164,7 +164,7 @@ def _handle_currency_field(model, name, kwargs):
     name = _get_clean_name(model, name)
     field = _get_field(model, name)
     money_field = field.price_field
-    if money_field.default is not None and money_field.name not in kwargs:
+    if money_field.default is not NOT_PROVIDED and money_field.name not in kwargs:
         kwargs["defaults"] = kwargs.get("defaults", {})
         kwargs["defaults"][money_field.name] = money_field.default.amount
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,10 @@ Changelog
 
 - Improved localization: New setting ``CURRENCY_DECIMAL_PLACES_DISPLAY`` configures decimal places to display for each configured currency `#521`_ (`wearebasti`_)
 
+**Changed**
+
+- Set the default value for ``models.fields.MoneyField`` to ``NOT_PROVIDED``.
+
 **Fixed**
 
 - Pin ``pymoneyed<1.0`` as it changed the ``repr`` output of the ``Money`` class.

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ test_requirements = [
     "pytest-pythonpath",
     "pytest-cov",
     "django-reversion",
+    "mixer",
 ]
 
 extras_requirements = {

--- a/tests/migrations/test_migrations.py
+++ b/tests/migrations/test_migrations.py
@@ -70,7 +70,7 @@ class TestMigrationFramework:
             + "from tests.migrations.helpers import makemigrations; makemigrations();"
         )
 
-    def make_default_migration(self, field="MoneyField(max_digits=10, decimal_places=2)"):
+    def make_default_migration(self, field="MoneyField(max_digits=10, decimal_places=2, null=True)"):
         return self.make_migration(field=field)
 
     def run(self, content):
@@ -152,7 +152,7 @@ class TestMigrationFramework:
 
     def test_alter_field(self):
         self.make_default_migration()
-        migration = self.make_migration(field="MoneyField(max_digits=15, decimal_places=2)")
+        migration = self.make_migration(field="MoneyField(max_digits=15, decimal_places=2, null=True)")
         migration.stdout.fnmatch_lines(
             ["*Migrations for 'money_app':*", "*0002_test.py*", "*- Alter field field on model*"]
         )
@@ -188,7 +188,7 @@ class TestMigrationFramework:
         self.make_default_migration()
         self.assert_migrate(["*Applying money_app.0001_test... OK*"])
         self.create_instance()
-        migration = self.make_migration(new_field="MoneyField(max_digits=10, decimal_places=2)")
+        migration = self.make_migration(new_field="MoneyField(max_digits=10, decimal_places=2, null=True)")
         migration.stdout.fnmatch_lines(
             [
                 "*Migrations for 'money_app':*",
@@ -209,8 +209,8 @@ class TestMigrationFramework:
         result.stdout.fnmatch_lines(["US$10.00"])
 
     def test_migrate_to_moneyfield(self):
-        self.make_default_migration(field="models.DecimalField(max_digits=10, decimal_places=2)")
-        migration = self.make_migration(field="MoneyField(max_digits=10, decimal_places=2)")
+        self.make_default_migration(field="models.DecimalField(max_digits=10, decimal_places=2, null=True)")
+        migration = self.make_migration(field="MoneyField(max_digits=10, decimal_places=2, null=True)")
         migration.stdout.fnmatch_lines(
             ["*Migrations for 'money_app':*", "*0002_test.py*", "*- Add field field_currency to model*"]
         )
@@ -218,7 +218,7 @@ class TestMigrationFramework:
 
     def test_migrate_from_moneyfield(self):
         self.make_default_migration()
-        migration = self.make_migration(field="models.DecimalField(max_digits=10, decimal_places=2)")
+        migration = self.make_migration(field="models.DecimalField(max_digits=10, decimal_places=2, null=True)")
         migration.stdout.fnmatch_lines(
             ["*Migrations for 'money_app':*", "*0002_test.py*", "*- Remove field field_currency from model*"]
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,7 @@ from copy import copy
 
 from django import VERSION
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import IntegrityError, models
 from django.db.migrations.writer import MigrationWriter
 from django.db.models import Case, F, Func, Q, Value, When
 from django.utils.translation import override
@@ -347,6 +347,11 @@ class TestNullableCurrency:
             ModelWithNullableCurrency.objects.create(money=10)
         assert str(exc.value) == "Missing currency value"
         assert not ModelWithNullableCurrency.objects.exists()
+
+    def test_fails_with_nullable_but_no_default(self):
+        with pytest.raises(IntegrityError) as exc:
+            ModelWithTwoMoneyFields.objects.create()
+        assert str(exc.value) == "NOT NULL constraint failed: testapp_modelwithtwomoneyfields.amount1"
 
     def test_query_not_null(self):
         money = Money(100, "EUR")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,6 +17,7 @@ import pytest
 
 from djmoney.models.fields import MoneyField
 from djmoney.money import Money
+from mixer.backend.django import mixer
 from moneyed import Money as OldMoney
 
 from .testapp.models import (
@@ -746,3 +747,9 @@ def test_distinct_through_wrapper():
     queryset = ProxyModelWrapper.objects.distinct()
 
     assert queryset.count() == 3
+
+
+def test_mixer_blend():
+    instance = mixer.blend(ModelWithTwoMoneyFields)
+    assert isinstance(instance.amount1, Money)
+    assert isinstance(instance.amount2, Money)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,7 +17,6 @@ import pytest
 
 from djmoney.models.fields import MoneyField
 from djmoney.money import Money
-from mixer.backend.django import mixer
 from moneyed import Money as OldMoney
 
 from .testapp.models import (
@@ -750,6 +749,11 @@ def test_distinct_through_wrapper():
 
 
 def test_mixer_blend():
-    instance = mixer.blend(ModelWithTwoMoneyFields)
-    assert isinstance(instance.amount1, Money)
-    assert isinstance(instance.amount2, Money)
+    try:
+        from mixer.backend.django import mixer
+    except AttributeError:
+        pass  # mixer doesn't work with pypy
+    else:
+        instance = mixer.blend(ModelWithTwoMoneyFields)
+        assert isinstance(instance.amount1, Money)
+        assert isinstance(instance.amount2, Money)


### PR DESCRIPTION
Thanks for the great work on Django-Money.

Our usage of the MoneyField in our models requires that it can be mixer/faked for test purposes. This is currently not possible, because the default is None and mixer will assume that it was set intentionally and would not change/fake it.
With the correct change that the field no longer defaults to 0, a lot of our test failed. This was caused by the fact that the default is now None.
The mixer package presumes that if the default is NOT_PROVIDED, then there was no default value in the definition of the field on the model. In that case it will generate an proper value for the field when the model instance was created by mixer.blend(). This allows us to let mixer fill in the non trivial required MoneyFields.
an extra issue arose in the migration tests when the default was now NOT_PROVIDED, this triggered the makemigration to check if null was allowed and if it was not an initialisation migration, it would correctly ask for a one-time value so it could update instances if need be.

I hope that my contribution is appreciated, if any questions or remarks arise, I will be happy to answer them.