### PR TITLE
fix: `DeprecationWarning` related to the usage of `cafile` in `urlopen`

### DIFF
--- a/djmoney/contrib/exchange/backends/base.py
+++ b/djmoney/contrib/exchange/backends/base.py
@@ -1,4 +1,5 @@
 import json
+import ssl
 from decimal import Decimal
 from urllib.parse import parse_qsl, urlparse, urlunparse
 from urllib.request import urlopen
@@ -45,7 +46,8 @@ class BaseExchangeBackend:
 
     def get_response(self, **params):
         url = self.get_url(**params)
-        response = urlopen(url, cafile=certifi.where())
+        context = ssl.create_default_context(cafile=certifi.where())
+        response = urlopen(url, context=context)
         return response.read()
 
     def parse_json(self, response):

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Fixed
 ~~~~~
 
 - Resulting Money object from arithmetics (add / sub / ...) inherits maximum decimal_places from arguments `#522`_ (`wearebasti`_)
+- ``DeprecationWarning`` related to the usage of ``cafile`` in ``urlopen``. `#553`_ (`Stranger6667`_)
 
 Added
 ~~~~~
@@ -705,6 +706,7 @@ Added
 .. _0.3: https://github.com/django-money/django-money/compare/0.2...0.3
 .. _0.2: https://github.com/django-money/django-money/compare/0.2...a6d90348085332a393abb40b86b5dd9505489b04
 
+.. _#553: https://github.com/django-money/django-money/issues/553
 .. _#541: https://github.com/django-money/django-money/issues/541
 .. _#534: https://github.com/django-money/django-money/issues/534
 .. _#515: https://github.com/django-money/django-money/issues/515

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     django30: {[django]3.0.x}
     django31: {[django]3.1.x}
     django_master: {[django]master}
-commands = py.test --ds=tests.settings --cov=./djmoney {posargs}
+commands = py.test --ds=tests.settings --cov=./djmoney {posargs} -W error::DeprecationWarning
 usedevelop = false
 
 [testenv:lint]


### PR DESCRIPTION
Fixes #553