### PR TITLE
fix for aggregation through proxy model

### DIFF
--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -177,6 +177,9 @@ def _get_model(args, func):
     if hasattr(func, "__self__"):
         # Bound method
         model = func.__self__.model
+    elif hasattr(func, "__wrapped__"):
+        # Proxy model
+        model = func.__wrapped__.__self__.model
     else:
         # Custom method on user-defined model manager.
         model = args[0].model

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -44,8 +44,10 @@ from .testapp.models import (
     ModelWithTwoMoneyFields,
     ModelWithUniqueIdAndCurrency,
     ModelWithVanillaMoneyField,
+    NotNullMoneyFieldModel,
     NullMoneyFieldModel,
     ProxyModel,
+    ProxyModelWrapper,
     SimpleModel,
 )
 
@@ -729,3 +731,13 @@ def test_order_by():
 
     qs = ModelWithVanillaMoneyField.objects.order_by("integer").filter(money=Money(10, "AUD"))
     assert list(map(extract_data, qs)) == [(Money(10, "AUD"), 1), (Money(10, "AUD"), 2)]
+
+
+def test_distinct_through_wrapper():
+    NotNullMoneyFieldModel.objects.create(money=10, money_currency="USD")
+    NotNullMoneyFieldModel.objects.create(money=100, money_currency="USD")
+    NotNullMoneyFieldModel.objects.create(money=10, money_currency="EUR")
+
+    queryset = ProxyModelWrapper.objects.distinct()
+
+    assert queryset.count() == 3

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -118,6 +118,21 @@ class NullMoneyFieldModel(models.Model):
     field = MoneyField(max_digits=10, decimal_places=2, null=True, default_currency="USD", blank=True)
 
 
+class ModelManager(models.Manager):
+    pass
+
+
+class NotNullMoneyFieldModel(models.Model):
+    money = MoneyField(max_digits=10, decimal_places=2)
+
+    objects = money_manager(ModelManager())
+
+
+class ProxyModelWrapper(NotNullMoneyFieldModel):
+    class Meta:
+        proxy = True
+
+
 class ProxyModel(SimpleModel):
     class Meta:
         proxy = True


### PR DESCRIPTION
since version 1.0 the option of using the queryset.distinct(), etc.. through a proxymodel of a model with money_manager failed. It could not find the model and raised an exception in manager.py:200 `IndexError: tuple index out of range`. 
Returned old code and wrote a test for coverage. 