### PR TITLE
Fix __truediv__ if result is Decimal

### DIFF
--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -58,7 +58,8 @@ class Money(DefaultMoney):
         if isinstance(other, F):
             return other.__rtruediv__(self)
         result = super().__truediv__(other)
-        result.decimal_places = self._fix_decimal_places(other)
+        if isinstance(result, self.__class__):
+            result.decimal_places = self._fix_decimal_places(other)
         return result
 
     def __rtruediv__(self, other):

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -27,6 +27,7 @@ def test_default_mul():
 
 def test_default_truediv():
     assert Money(10, "USD") / 2 == Money(5, "USD")
+    assert Money(10, "USD") / Money(2, "USD") == 5
 
 
 def test_reverse_truediv_fails():


### PR DESCRIPTION
`__truediv__` can return a decimal, in which case decimal_places cannot be set.

See https://github.com/django-money/django-money/issues/522#issuecomment-743001682
