### PR TITLE
fix: Pin `pymoneyed<1.0`

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,9 @@ Changelog
 
 - Improved localization: New setting ``CURRENCY_DECIMAL_PLACES_DISPLAY`` configures decimal places to display for each configured currency `#521`_ (`wearebasti`_)
 
+**Fixed**
+
+- Pin ``pymoneyed<1.0`` as it changed the ``repr`` output of the ``Money`` class.
 
 `1.2.2`_ - 2020-12-29
 ---------------------

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     maintainer_email="greg@reinbach.com",
     license="BSD",
     packages=find_packages(include=["djmoney", "djmoney.*"]),
-    install_requires=["setuptools", "Django>=1.11", "py-moneyed>=0.8"],
+    install_requires=["setuptools", "Django>=1.11", "py-moneyed>=0.8,<1.0"],
     python_requires=">=3.5",
     platforms=["Any"],
     keywords=["django", "py-money", "money"],


### PR DESCRIPTION
It changed `Money.__repr__` which is a minor, but incompatible change.

In practice, we can disable `-W error::DeprecationWarning` in our tests, fix the `__repr__` so it is compatible with the previous behavior, but I don't want to go this way as we won't use the new `pymoneyed` features anyway and users will have warnings in their code. It will be easier to add support for new features in the new `django-money` release instead.

This PR allows us to avoid the warning in tests and don't have a failing CI in PRs