### PR TITLE
fix: Subtracting `Money` from `moneyed.Money`

### DIFF
--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -106,7 +106,6 @@ class Money(DefaultMoney):
     # we overwrite the 'targets' so the wrong synonyms are called
     # Example: we overwrite __add__; __radd__ calls __add__ on DefaultMoney...
     __radd__ = __add__
-    __rsub__ = __sub__
     __rmul__ = __mul__
 
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ Changelog
 **Fixed**
 
 - Pin ``pymoneyed<1.0`` as it changed the ``repr`` output of the ``Money`` class.
+- Subtracting ``Money`` from ``moneyed.Money``. Regression, introduced in ``1.2``. `#593`_
 
 `1.2.2`_ - 2020-12-29
 ---------------------
@@ -694,6 +695,7 @@ wrapping with ``money_manager``.
 .. _0.3: https://github.com/django-money/django-money/compare/0.2...0.3
 .. _0.2: https://github.com/django-money/django-money/compare/0.2...a6d90348085332a393abb40b86b5dd9505489b04
 
+.. _#593: https://github.com/django-money/django-money/issues/593
 .. _#586: https://github.com/django-money/django-money/issues/586
 .. _#585: https://github.com/django-money/django-money/pull/585
 .. _#583: https://github.com/django-money/django-money/issues/583

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -2,7 +2,7 @@ from django.utils.translation import override
 
 import pytest
 
-from djmoney.money import Money, get_current_locale
+from djmoney.money import DefaultMoney, Money, get_current_locale
 
 
 def test_repr():
@@ -114,3 +114,12 @@ def test_decimal_places_display_overwrite():
     assert str(number) == "$1.23457"
     number.decimal_places_display = None
     assert str(number) == "$1.23"
+
+
+def test_sub_negative():
+    # See GH-593
+    total = DefaultMoney(0, "EUR")
+    bills = (Money(8, "EUR"), Money(25, "EUR"))
+    for bill in bills:
+        total -= bill
+    assert total == Money(-33, "EUR")


### PR DESCRIPTION
Fixes #593 