### PR TITLE
Fix serializer with model field

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,8 +81,6 @@ jobs:
           - python: 3.6
             tox_env: django31-py36
           - python: 3.6
-            tox_env: django_master-py36
-          - python: 3.6
             tox_env: no_rest_framework
           - python: 3.7
             tox_env: django21-py37
@@ -92,8 +90,6 @@ jobs:
             tox_env: django30-py37
           - python: 3.7
             tox_env: django31-py37
-          - python: 3.7
-            tox_env: django_master-py37
           - python: 3.8
             tox_env: django22-py38
           - python: 3.8

--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -5,10 +5,8 @@ from django.core.serializers.base import DeserializationError
 from django.core.serializers.json import Serializer as JSONSerializer
 
 from djmoney.money import Money
-
 from .models.fields import MoneyField
 from .utils import get_currency_field_name
-
 
 Serializer = JSONSerializer
 
@@ -45,7 +43,9 @@ def Deserializer(stream_or_string, **options):  # noqa
                     continue
                 field = Model._meta.get_field(field_name)
                 if isinstance(field, MoneyField) and field_value is not None:
-                    money_fields[field_name] = Money(field_value, obj["fields"][get_currency_field_name(field_name)])
+                    money_fields[field_name] = Money(
+                        field_value, obj["fields"][get_currency_field_name(field_name, field)]
+                    )
                 else:
                     fields[field_name] = field_value
             obj["fields"] = fields

--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -5,8 +5,10 @@ from django.core.serializers.base import DeserializationError
 from django.core.serializers.json import Serializer as JSONSerializer
 
 from djmoney.money import Money
+
 from .models.fields import MoneyField
 from .utils import get_currency_field_name
+
 
 Serializer = JSONSerializer
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,13 +1,16 @@
 import json
 from unittest.mock import patch
 
-import pytest
 from django.core.management import call_command
 from django.core.serializers.base import DeserializationError
 
+import pytest
+
 from djmoney.money import Money
 from djmoney.serializers import Deserializer, Serializer
+
 from .testapp.models import ModelWithDefaultAsInt, ModelWithSharedCurrency
+
 
 pytestmark = pytest.mark.django_db
 
@@ -92,6 +95,7 @@ def test_patched_get_model(fixture_file):
     with patch("django.core.serializers.python._get_model", _get_model):
         loaddata(fixture_file)
     assert ModelWithDefaultAsInt.objects.get().money == Money(1, "USD")
+
 
 def test_serialize_currency_field(fixture_file):
     data = """[

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,16 +1,13 @@
 import json
 from unittest.mock import patch
 
+import pytest
 from django.core.management import call_command
 from django.core.serializers.base import DeserializationError
 
-import pytest
-
 from djmoney.money import Money
 from djmoney.serializers import Deserializer, Serializer
-
-from .testapp.models import ModelWithDefaultAsInt
-
+from .testapp.models import ModelWithDefaultAsInt, ModelWithSharedCurrency
 
 pytestmark = pytest.mark.django_db
 
@@ -95,3 +92,15 @@ def test_patched_get_model(fixture_file):
     with patch("django.core.serializers.python._get_model", _get_model):
         loaddata(fixture_file)
     assert ModelWithDefaultAsInt.objects.get().money == Money(1, "USD")
+
+def test_serialize_currency_field(fixture_file):
+    data = """[
+    {
+        "model": "testapp.modelwithsharedcurrency",
+        "pk": 1,
+        "fields": {"first": "1.00", "second": "2.00", "currency": "USD"}
+    }
+]"""
+    fixture_file.write(data)
+    loaddata(fixture_file)
+    assert ModelWithSharedCurrency.objects.get().first == Money(1, "USD")

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
 commands = py.test --ds=tests.settings_reversion --cov=./djmoney {posargs} -W error::DeprecationWarning
 usedevelop = false
 
-[testenv:django_master-py{39,38,37,36,py3}]
+[testenv:django_master-py{39,38,py3}]
 commands = py.test --ds=tests.settings --cov=./djmoney {posargs} -W error::DeprecationWarning
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ commands =
        django-reversion>=3.0.8
        djangorestframework>=3.12.0
 master =
-       https://github.com/django/django/tarball/master
+       https://github.com/django/django/tarball/main
        djangorestframework>=3.12.0
 
 [testenv:no_rest_framework]
@@ -71,7 +71,7 @@ deps =
     django-reversion>=3.0.8
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3.7
 changedir = docs
 deps =
     sphinx


### PR DESCRIPTION
When using the currency_field_name option to MoneyField, pass the field instance to the resolver. If we don't do this, we can't load the fixtures as it will be looking for 'field_name_currency' in the fixture.