### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
 
       - run: pip install pre-commit
       - run: pre-commit run --all-files
+
   docs:
     name: docs
     runs-on: ubuntu-latest
@@ -33,22 +34,6 @@ jobs:
 
       - name: Run docs tox job
         run: tox -e docs
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - run: pip install tox
-
-      - name: Run lint tox job
-        run: tox -e lint
 
   tests:
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: check-yaml
@@ -11,26 +11,39 @@ repos:
         args:
         - --remove
 
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.12.0
+    hooks:
+    -   id: pyupgrade
+        args:
+        - --py3-plus
+
 -   repo: https://github.com/asottile/seed-isort-config
     rev: v2.2.0
     hooks:
       - id: seed-isort-config
 
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.6.4
+    rev: v5.8.0
     hooks:
       -   id: isort
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.1
     hooks:
     -   id: flake8
         exclude: ^docs
 
 -   repo: https://github.com/myint/rstcheck
-    rev: master
+    rev: 3f92957
     hooks:
       - id: rstcheck
         additional_dependencies:
           - sphinx==3.1.2
         args: [--ignore-directives=code]
+
+-   repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        exclude: ^docs

--- a/djmoney/contrib/exchange/models.py
+++ b/djmoney/contrib/exchange/models.py
@@ -42,7 +42,7 @@ def get_rate(source, target, backend=None):
     """
     if backend is None:
         backend = get_default_backend_name()
-    key = "djmoney:get_rate:%s:%s:%s" % (source, target, backend)
+    key = "djmoney:get_rate:{}:{}:{}".format(source, target, backend)
     result = cache.get(key)
     if result is not None:
         return result
@@ -57,7 +57,7 @@ def _get_rate(source, target, backend):
         return 1
     rates = Rate.objects.filter(currency__in=(source, target), backend=backend).select_related("backend")
     if not rates:
-        raise MissingRate("Rate %s -> %s does not exist" % (source, target))
+        raise MissingRate("Rate {} -> {} does not exist".format(source, target))
     if len(rates) == 1:
         return _try_to_get_rate_directly(source, target, rates[0])
     return _get_rate_via_base(rates, target)
@@ -74,7 +74,7 @@ def _try_to_get_rate_directly(source, target, rate):
     elif rate.backend.base_currency == target and rate.currency == source:
         return 1 / rate.value
     # Case when target or source is not a base currency
-    raise MissingRate("Rate %s -> %s does not exist" % (source, target))
+    raise MissingRate("Rate {} -> {} does not exist".format(source, target))
 
 
 def _get_rate_via_base(rates, target):

--- a/djmoney/forms/fields.py
+++ b/djmoney/forms/fields.py
@@ -32,7 +32,7 @@ class MoneyField(MultiValueField):
             min_value=min_value,
             max_digits=max_digits,
             decimal_places=decimal_places,
-            **kwargs
+            **kwargs,
         )
         currency_field = ChoiceField(choices=currency_choices)
 

--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -154,7 +154,7 @@ def get_current_locale():
     if locale.upper() in _FORMATTER.formatting_definitions:
         return locale
 
-    locale = ("%s_%s" % (locale, locale)).upper()
+    locale = ("{}_{}".format(locale, locale)).upper()
     if locale in _FORMATTER.formatting_definitions:
         return locale
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,9 +52,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Django-money'
-copyright = u'2016, Jacob Hansson'
-author = u'Jacob Hansson'
+project = 'Django-money'
+copyright = '2016, Jacob Hansson'
+author = 'Jacob Hansson'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -227,8 +227,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Django-money.tex', u'Django-money Documentation',
-     u'Jacob Hansson', 'manual'),
+    (master_doc, 'Django-money.tex', 'Django-money Documentation',
+     'Jacob Hansson', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -257,7 +257,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'django-money', u'Django-money Documentation',
+    (master_doc, 'django-money', 'Django-money Documentation',
      [author], 1)
 ]
 
@@ -271,7 +271,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Django-money', u'Django-money Documentation',
+    (master_doc, 'Django-money', 'Django-money Documentation',
      author, 'Django-money', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 120
+target-version = ["py35"]

--- a/tests/contrib/exchange/test_model.py
+++ b/tests/contrib/exchange/test_model.py
@@ -46,13 +46,13 @@ def test_rates_via_base(source, target, expected, django_assert_num_queries):
 @pytest.mark.parametrize("source, target", (("NOK", "ZAR"), ("ZAR", "NOK"), ("USD", "ZAR"), ("ZAR", "USD")))
 @pytest.mark.usefixtures("default_openexchange_rates")
 def test_unknown_currency_with_partially_exiting_currencies(source, target):
-    with pytest.raises(MissingRate, match="Rate %s \\-\\> %s does not exist" % (source, target)):
+    with pytest.raises(MissingRate, match="Rate {} \\-\\> {} does not exist".format(source, target)):
         get_rate(source, target)
 
 
 @pytest.mark.parametrize("source, target", (("USD", "EUR"), ("SEK", "ZWL")))
 def test_unknown_currency(source, target):
-    with pytest.raises(MissingRate, match="Rate %s \\-\\> %s does not exist" % (source, target)):
+    with pytest.raises(MissingRate, match="Rate {} \\-\\> {} does not exist".format(source, target)):
         get_rate(source, target)
 
 

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -111,8 +111,8 @@ class TestMoneyField:
     @pytest.mark.parametrize(
         "value, error",
         (
-            (Money(50, "EUR"), u"Ensure this value is greater than or equal to 100.00 €."),
-            (Money(1500, "EUR"), u"Ensure this value is less than or equal to 1,000.00 €."),
+            (Money(50, "EUR"), "Ensure this value is greater than or equal to 100.00 €."),
+            (Money(1500, "EUR"), "Ensure this value is less than or equal to 1,000.00 €."),
             (Money(40, "USD"), "Ensure this value is greater than or equal to $50.00."),
             (Money(600, "USD"), "Ensure this value is less than or equal to $500.00."),
             (Money(400, "NOK"), "Ensure this value is greater than or equal to 500.00 Nkr."),

--- a/tests/migrations/helpers.py
+++ b/tests/migrations/helpers.py
@@ -19,7 +19,7 @@ def makemigrations():
 
 
 def get_migration(name):
-    return __import__("money_app.migrations.%s_%s" % (name, MIGRATION_NAME), fromlist=["Migration"]).Migration
+    return __import__("money_app.migrations.{}_{}".format(name, MIGRATION_NAME), fromlist=["Migration"]).Migration
 
 
 def get_operations(migration_name):

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -131,8 +131,8 @@ class TestValidation:
     @pytest.mark.parametrize(
         "value, error",
         (
-            (Money(50, "EUR"), u"Ensure this value is greater than or equal to 100.00 €."),
-            (Money(1500, "EUR"), u"Ensure this value is less than or equal to 1,000.00 €."),
+            (Money(50, "EUR"), "Ensure this value is greater than or equal to 100.00 €."),
+            (Money(1500, "EUR"), "Ensure this value is less than or equal to 1,000.00 €."),
             (Money(40, "USD"), "Ensure this value is greater than or equal to $50.00."),
             (Money(600, "USD"), "Ensure this value is less than or equal to $500.00."),
             (Money(400, "NOK"), "Ensure this value is greater than or equal to 500.00 Nkr."),
@@ -171,7 +171,7 @@ class TestValidation:
     def test_default_django_validator(self):
         form = MoneyModelFormWithValidation(data={"balance_0": 0, "balance_1": "GBP"})
         assert not form.is_valid()
-        assert form.errors == {"balance": [u"Ensure this value is greater than or equal to GB£100.00."]}
+        assert form.errors == {"balance": ["Ensure this value is greater than or equal to GB£100.00."]}
 
 
 class TestDisabledField:

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -10,7 +10,7 @@ def test_repr():
 
 
 def test_html_safe():
-    assert Money("10.5", "EUR").__html__() == u"10.50\xa0€"
+    assert Money("10.5", "EUR").__html__() == "10.50\xa0€"
 
 
 def test_html_unsafe():

--- a/tox.ini
+++ b/tox.ini
@@ -31,13 +31,9 @@ commands = py.test --ds=tests.settings --cov=./djmoney {posargs} -W error::Depre
 
 [testenv:lint]
 deps =
-    flake8
-    isort
-    black
+    pre-commit
 commands =
-    flake8 {toxinidir}/djmoney {toxinidir}/tests
-    isort -c {toxinidir}/djmoney {toxinidir}/tests
-    black -l 120 --check --diff {toxinidir}/djmoney {toxinidir}/tests setup.py
+    pre-commit run --all-files
 
 [django]
 1.11.x  =


### PR DESCRIPTION
- Add and apply pre-commit hooks for black and pyupgrade.
- Remove the lint step from the CI workflow as it now fully duplicates
  what the pre-commit step does.
- Update pre-commit hooks with `pre-commit autoupdate`.
- Pin the rstcheck hook to a commit hash.