### PR TITLE
Drop support for legacy versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - run: pip install tox
 
@@ -40,53 +40,27 @@ jobs:
       matrix:
         include:
           - python: pypy3
-            tox_env: django111-pypy3
-          - python: pypy3
-            tox_env: django21-pypy3
-          - python: pypy3
             tox_env: django22-pypy3
           - python: pypy3
-            tox_env: django30-pypy3
-          - python: pypy3
             tox_env: django31-pypy3
-          - python: 3.5
-            tox_env: django111-py35
-          - python: 3.5
-            tox_env: django21-py35
-          - python: 3.5
-            tox_env: django22-py35
-          - python: 3.6
-            tox_env: django111-py36
-          - python: 3.6
-            tox_env: django21-py36
           - python: 3.6
             tox_env: django22-py36
-          - python: 3.6
-            tox_env: django30-py36
           - python: 3.6
             tox_env: django31-py36
           - python: 3.6
             tox_env: no_rest_framework
           - python: 3.7
-            tox_env: django21-py37
-          - python: 3.7
             tox_env: django22-py37
-          - python: 3.7
-            tox_env: django30-py37
           - python: 3.7
             tox_env: django31-py37
           - python: 3.8
             tox_env: django22-py38
-          - python: 3.8
-            tox_env: django30-py38
           - python: 3.8
             tox_env: django31-py38
           - python: 3.8
             tox_env: django_master-py38
           - python: 3.9
             tox_env: django22-py39
-          - python: 3.9
-            tox_env: django30-py39
           - python: 3.9
             tox_env: django31-py39
           - python: 3.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
     -   id: pyupgrade
         args:
-        - --py3-plus
+        - --py36-plus
 
 -   repo: https://github.com/asottile/seed-isort-config
     rev: v2.2.0

--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,8 @@ django-money
 A little Django app that uses `py-moneyed <https://github.com/py-moneyed/py-moneyed>`__ to add support for Money
 fields in your models and forms.
 
-* Django versions supported: 1.11, 2.1, 2.2, 3.0, 3.1
-* Python versions supported: 3.5, 3.6, 3.7, 3.8, 3.9
+* Django versions supported: 2.2, 3.1, 3.2
+* Python versions supported: 3.6, 3.7, 3.8, 3.9
 * PyPy versions supported: PyPy3
 
 If you need support for older versions of Django and Python, please refer to older releases mentioned in `the release notes <https://django-money.readthedocs.io/en/latest/changes.html>`__.

--- a/djmoney/apps.py
+++ b/djmoney/apps.py
@@ -3,6 +3,7 @@ from django.apps import AppConfig
 
 class MoneyConfig(AppConfig):
     name = "djmoney"
+    default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
         try:

--- a/djmoney/contrib/exchange/models.py
+++ b/djmoney/contrib/exchange/models.py
@@ -42,7 +42,7 @@ def get_rate(source, target, backend=None):
     """
     if backend is None:
         backend = get_default_backend_name()
-    key = "djmoney:get_rate:{}:{}:{}".format(source, target, backend)
+    key = f"djmoney:get_rate:{source}:{target}:{backend}"
     result = cache.get(key)
     if result is not None:
         return result
@@ -57,7 +57,7 @@ def _get_rate(source, target, backend):
         return 1
     rates = Rate.objects.filter(currency__in=(source, target), backend=backend).select_related("backend")
     if not rates:
-        raise MissingRate("Rate {} -> {} does not exist".format(source, target))
+        raise MissingRate(f"Rate {source} -> {target} does not exist")
     if len(rates) == 1:
         return _try_to_get_rate_directly(source, target, rates[0])
     return _get_rate_via_base(rates, target)
@@ -74,7 +74,7 @@ def _try_to_get_rate_directly(source, target, rate):
     elif rate.backend.base_currency == target and rate.currency == source:
         return 1 / rate.value
     # Case when target or source is not a base currency
-    raise MissingRate("Rate {} -> {} does not exist".format(source, target))
+    raise MissingRate(f"Rate {source} -> {target} does not exist")
 
 
 def _get_rate_via_base(rates, target):

--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -186,7 +186,7 @@ def get_current_locale(for_babel=True):
     if locale.upper() in moneyed.localization._FORMATTER.formatting_definitions:
         return locale
 
-    locale = ("{}_{}".format(locale, locale)).upper()
+    locale = f"{locale}_{locale}".upper()
     if locale in moneyed.localization._FORMATTER.formatting_definitions:
         return locale
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+- Drop support for Django 1.11, 2.1 and 3.0.
+- Drop support for Python 3.5.
+- Add support for Django 3.2.
+
 `2.0.3`_ - 2021-09-04
 ---------------------
 

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,10 @@ def find_version():
 setup(
     name="django-money",
     version=find_version(),
-    description="Adds support for using money and currency fields in django models and forms. "
-    "Uses py-moneyed as the money implementation.",
+    description=(
+        "Adds support for using money and currency fields in django models and forms. "
+        "Uses py-moneyed as the money implementation."
+    ),
     long_description=read("README.rst"),
     long_description_content_type="text/x-rst",
     url="https://github.com/django-money/django-money",
@@ -64,8 +66,8 @@ setup(
     maintainer_email="greg@reinbach.com",
     license="BSD",
     packages=find_packages(include=["djmoney", "djmoney.*"]),
-    install_requires=["setuptools", "Django>=1.11", "py-moneyed>=1.2,<2.0"],
-    python_requires=">=3.5",
+    install_requires=["setuptools", "Django>=2.2", "py-moneyed>=1.2,<2.0"],
+    python_requires=">=3.6",
     platforms=["Any"],
     keywords=["django", "py-money", "money"],
     classifiers=[
@@ -74,14 +76,11 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.0",
         "Framework :: Django :: 3.1",
+        "Framework :: Django :: 3.2",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tests/contrib/exchange/test_model.py
+++ b/tests/contrib/exchange/test_model.py
@@ -46,13 +46,13 @@ def test_rates_via_base(source, target, expected, django_assert_num_queries):
 @pytest.mark.parametrize("source, target", (("NOK", "ZAR"), ("ZAR", "NOK"), ("USD", "ZAR"), ("ZAR", "USD")))
 @pytest.mark.usefixtures("default_openexchange_rates")
 def test_unknown_currency_with_partially_exiting_currencies(source, target):
-    with pytest.raises(MissingRate, match="Rate {} \\-\\> {} does not exist".format(source, target)):
+    with pytest.raises(MissingRate, match=f"Rate {source} \\-\\> {target} does not exist"):
         get_rate(source, target)
 
 
 @pytest.mark.parametrize("source, target", (("USD", "EUR"), ("SEK", "ZWL")))
 def test_unknown_currency(source, target):
-    with pytest.raises(MissingRate, match="Rate {} \\-\\> {} does not exist".format(source, target)):
+    with pytest.raises(MissingRate, match=f"Rate {source} \\-\\> {target} does not exist"):
         get_rate(source, target)
 
 

--- a/tests/migrations/helpers.py
+++ b/tests/migrations/helpers.py
@@ -19,7 +19,7 @@ def makemigrations():
 
 
 def get_migration(name):
-    return __import__("money_app.migrations.{}_{}".format(name, MIGRATION_NAME), fromlist=["Migration"]).Migration
+    return __import__(f"money_app.migrations.{name}_{MIGRATION_NAME}", fromlist=["Migration"]).Migration
 
 
 def get_operations(migration_name):

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
 envlist =
     django_master-py{39,38,37,36,py3}
+    django32-py{39,38,37,36,py3}
     django31-py{39,38,37,36,py3}
-    django30-py{39,38,37,36,py3}
     django22-py{39,38,37,36,py3}
-    django21-py{37,36,35,py3}
-    django111-py{36,35,py3}
     lint
     docs
 skipsdist = true
@@ -17,11 +15,9 @@ python_paths = {toxinidir}
 [testenv]
 deps =
     .[test,exchange]
-    django111: {[django]1.11.x}
-    django21: {[django]2.1.x}
     django22: {[django]2.2.x}
-    django30: {[django]3.0.x}
     django31: {[django]3.1.x}
+    django32: {[django]3.2.x}
     django_master: {[django]master}
 commands = py.test --ds=tests.settings_reversion --cov=./djmoney {posargs}
 usedevelop = false
@@ -36,26 +32,18 @@ commands =
     pre-commit run --all-files
 
 [django]
-1.11.x  =
-       Django>=1.11.0,<2.0.0
-       django-reversion>=2.0.8,<3.0.8
-       djangorestframework>=3.6.2
-2.1.x  =
-       Django>=2.1,<2.2
-       django-reversion>=2.0.8
-       djangorestframework>=3.7.3
 2.2.x  =
        Django>=2.2,<2.3
-       django-reversion>=2.0.8
-       djangorestframework>=3.7.3
-3.0.x  =
-       Django>=3.0,<3.1
        django-reversion>=2.0.8
        djangorestframework>=3.7.3
 3.1.x  =
        Django>=3.1,<3.2
        django-reversion>=3.0.8
        djangorestframework>=3.12.0
+3.2.x  =
+        Django>=3.2,<3.3
+        django-reversion>=3.0.8
+        djangorestframework>=3.12.0
 master =
        https://github.com/django/django/tarball/main
        djangorestframework>=3.12.0
@@ -67,7 +55,7 @@ deps =
     django-reversion>=3.0.8
 
 [testenv:docs]
-basepython = python3.7
+allowlist_externals = make
 changedir = docs
 deps =
     sphinx


### PR DESCRIPTION
- Drop support for Django 1.11, 2.1 and 3.0.
- Drop support for Python 3.5.
- Add support for Django 3.2.