### PR TITLE
Currency max length defaults

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,11 @@ Searching for models with money fields:
         BankAccount.objects.filter(balance__gt=Money(1, 'USD'))
         # Returns the "account" object
 
+The default currency code length is `3` but you can change it with the `CURRENCY_CODE_MAX_LENGTH` setting.
+
+Caution: this setting also affects the initial migration of the `exchange` plugin, so changing it after running
+the initial migration has no effect. (You'd need to `manage migrate exchange zero` and migrate again if you want
+to change it).
 
 Field validation
 ----------------

--- a/djmoney/contrib/exchange/migrations/0001_initial.py
+++ b/djmoney/contrib/exchange/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 
 import django.db.models.deletion
 from django.db import migrations, models
-from djmoney.settings import CURRENCY_TICKER_MAX_LENGTH
+from djmoney.settings import CURRENCY_CODE_MAX_LENGTH
 
 class Migration(migrations.Migration):
 
@@ -16,14 +16,14 @@ class Migration(migrations.Migration):
             fields=[
                 ("name", models.CharField(max_length=255, primary_key=True, serialize=False)),
                 ("last_update", models.DateTimeField(auto_now=True)),
-                ("base_currency", models.CharField(max_length=CURRENCY_TICKER_MAX_LENGTH)),
+                ("base_currency", models.CharField(max_length=CURRENCY_CODE_MAX_LENGTH)),
             ],
         ),
         migrations.CreateModel(
             name="Rate",
             fields=[
                 ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
-                ("currency", models.CharField(max_length=CURRENCY_TICKER_MAX_LENGTH)),
+                ("currency", models.CharField(max_length=CURRENCY_CODE_MAX_LENGTH)),
                 ("value", models.DecimalField(decimal_places=6, max_digits=20)),
                 (
                     "backend",

--- a/djmoney/contrib/exchange/migrations/0001_initial.py
+++ b/djmoney/contrib/exchange/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 
 import django.db.models.deletion
 from django.db import migrations, models
-
+from djmoney.settings import CURRENCY_TICKER_MAX_LENGTH
 
 class Migration(migrations.Migration):
 
@@ -16,14 +16,14 @@ class Migration(migrations.Migration):
             fields=[
                 ("name", models.CharField(max_length=255, primary_key=True, serialize=False)),
                 ("last_update", models.DateTimeField(auto_now=True)),
-                ("base_currency", models.CharField(max_length=3)),
+                ("base_currency", models.CharField(max_length=CURRENCY_TICKER_MAX_LENGTH)),
             ],
         ),
         migrations.CreateModel(
             name="Rate",
             fields=[
                 ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
-                ("currency", models.CharField(max_length=3)),
+                ("currency", models.CharField(max_length=CURRENCY_TICKER_MAX_LENGTH)),
                 ("value", models.DecimalField(decimal_places=6, max_digits=20)),
                 (
                     "backend",

--- a/djmoney/contrib/exchange/migrations/0001_initial.py
+++ b/djmoney/contrib/exchange/migrations/0001_initial.py
@@ -2,7 +2,9 @@
 
 import django.db.models.deletion
 from django.db import migrations, models
+
 from djmoney.settings import CURRENCY_CODE_MAX_LENGTH
+
 
 class Migration(migrations.Migration):
 

--- a/djmoney/contrib/exchange/models.py
+++ b/djmoney/contrib/exchange/models.py
@@ -12,7 +12,7 @@ from .exceptions import MissingRate
 class ExchangeBackend(models.Model):
     name = models.CharField(max_length=255, primary_key=True)
     last_update = models.DateTimeField(auto_now=True)
-    base_currency = models.CharField(max_length=3)
+    base_currency = models.CharField(max_length=CURRENCY_TICKER_MAX_LENGTH)
 
     def __str__(self):
         return self.name

--- a/djmoney/contrib/exchange/models.py
+++ b/djmoney/contrib/exchange/models.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.utils.module_loading import import_string
 
-from djmoney.settings import EXCHANGE_BACKEND, RATES_CACHE_TIMEOUT, CURRENCY_TICKER_MAX_LENGTH
+from djmoney.settings import EXCHANGE_BACKEND, RATES_CACHE_TIMEOUT, CURRENCY_CODE_MAX_LENGTH
 
 from .exceptions import MissingRate
 
@@ -12,7 +12,7 @@ from .exceptions import MissingRate
 class ExchangeBackend(models.Model):
     name = models.CharField(max_length=255, primary_key=True)
     last_update = models.DateTimeField(auto_now=True)
-    base_currency = models.CharField(max_length=CURRENCY_TICKER_MAX_LENGTH)
+    base_currency = models.CharField(max_length=CURRENCY_CODE_MAX_LENGTH)
 
     def __str__(self):
         return self.name
@@ -22,7 +22,7 @@ class ExchangeBackend(models.Model):
 
 
 class Rate(models.Model):
-    currency = models.CharField(max_length=CURRENCY_TICKER_MAX_LENGTH)
+    currency = models.CharField(max_length=CURRENCY_CODE_MAX_LENGTH)
     value = models.DecimalField(max_digits=20, decimal_places=6)
     backend = models.ForeignKey(ExchangeBackend, on_delete=models.CASCADE, related_name="rates")
 

--- a/djmoney/contrib/exchange/models.py
+++ b/djmoney/contrib/exchange/models.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.utils.module_loading import import_string
 
-from djmoney.settings import EXCHANGE_BACKEND, RATES_CACHE_TIMEOUT, CURRENCY_CODE_MAX_LENGTH
+from djmoney.settings import CURRENCY_CODE_MAX_LENGTH, EXCHANGE_BACKEND, RATES_CACHE_TIMEOUT
 
 from .exceptions import MissingRate
 

--- a/djmoney/contrib/exchange/models.py
+++ b/djmoney/contrib/exchange/models.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.utils.module_loading import import_string
 
-from djmoney.settings import EXCHANGE_BACKEND, RATES_CACHE_TIMEOUT, MAX_TICKER_LENGTH
+from djmoney.settings import EXCHANGE_BACKEND, RATES_CACHE_TIMEOUT, CURRENCY_TICKER_MAX_LENGTH
 
 from .exceptions import MissingRate
 
@@ -22,7 +22,7 @@ class ExchangeBackend(models.Model):
 
 
 class Rate(models.Model):
-    currency = models.CharField(max_length=MAX_TICKER_LENGTH)
+    currency = models.CharField(max_length=CURRENCY_TICKER_MAX_LENGTH)
     value = models.DecimalField(max_digits=20, decimal_places=6)
     backend = models.ForeignKey(ExchangeBackend, on_delete=models.CASCADE, related_name="rates")
 

--- a/djmoney/contrib/exchange/models.py
+++ b/djmoney/contrib/exchange/models.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.utils.module_loading import import_string
 
-from djmoney.settings import EXCHANGE_BACKEND, RATES_CACHE_TIMEOUT
+from djmoney.settings import EXCHANGE_BACKEND, RATES_CACHE_TIMEOUT, MAX_TICKER_LENGTH
 
 from .exceptions import MissingRate
 
@@ -22,7 +22,7 @@ class ExchangeBackend(models.Model):
 
 
 class Rate(models.Model):
-    currency = models.CharField(max_length=3)
+    currency = models.CharField(max_length=MAX_TICKER_LENGTH)
     value = models.DecimalField(max_digits=20, decimal_places=6)
     backend = models.ForeignKey(ExchangeBackend, on_delete=models.CASCADE, related_name="rates")
 

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -14,7 +14,7 @@ from djmoney.money import Currency, Money
 from moneyed import Money as OldMoney
 
 from .._compat import setup_managers
-from ..settings import CURRENCY_CHOICES, DECIMAL_PLACES, DEFAULT_CURRENCY, MAX_TICKER_LENGTH
+from ..settings import CURRENCY_CHOICES, DECIMAL_PLACES, DEFAULT_CURRENCY, CURRENCY_TICKER_MAX_LENGTH
 from ..utils import MONEY_CLASSES, get_currency_field_name, prepare_expression
 
 
@@ -149,7 +149,7 @@ class CurrencyField(models.CharField):
     def __init__(self, price_field=None, default=DEFAULT_CURRENCY, **kwargs):
         if isinstance(default, Currency):
             default = default.code
-        kwargs.setdefault("max_length", MAX_TICKER_LENGTH)
+        kwargs.setdefault("max_length", CURRENCY_TICKER_MAX_LENGTH)
         self.price_field = price_field
         super().__init__(default=default, **kwargs)
 

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -14,7 +14,7 @@ from djmoney.money import Currency, Money
 from moneyed import Money as OldMoney
 
 from .._compat import setup_managers
-from ..settings import CURRENCY_CHOICES, DECIMAL_PLACES, DEFAULT_CURRENCY, CURRENCY_TICKER_MAX_LENGTH
+from ..settings import CURRENCY_CHOICES, DECIMAL_PLACES, DEFAULT_CURRENCY, CURRENCY_CODE_MAX_LENGTH
 from ..utils import MONEY_CLASSES, get_currency_field_name, prepare_expression
 
 
@@ -149,7 +149,7 @@ class CurrencyField(models.CharField):
     def __init__(self, price_field=None, default=DEFAULT_CURRENCY, **kwargs):
         if isinstance(default, Currency):
             default = default.code
-        kwargs.setdefault("max_length", CURRENCY_TICKER_MAX_LENGTH)
+        kwargs.setdefault("max_length", CURRENCY_CODE_MAX_LENGTH)
         self.price_field = price_field
         super().__init__(default=default, **kwargs)
 

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -14,7 +14,7 @@ from djmoney.money import Currency, Money
 from moneyed import Money as OldMoney
 
 from .._compat import setup_managers
-from ..settings import CURRENCY_CHOICES, DECIMAL_PLACES, DEFAULT_CURRENCY
+from ..settings import CURRENCY_CHOICES, DECIMAL_PLACES, DEFAULT_CURRENCY, MAX_TICKER_LENGTH
 from ..utils import MONEY_CLASSES, get_currency_field_name, prepare_expression
 
 
@@ -149,7 +149,7 @@ class CurrencyField(models.CharField):
     def __init__(self, price_field=None, default=DEFAULT_CURRENCY, **kwargs):
         if isinstance(default, Currency):
             default = default.code
-        kwargs.setdefault("max_length", 3)
+        kwargs.setdefault("max_length", MAX_TICKER_LENGTH)
         self.price_field = price_field
         super().__init__(default=default, **kwargs)
 

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -14,7 +14,7 @@ from djmoney.money import Currency, Money
 from moneyed import Money as OldMoney
 
 from .._compat import setup_managers
-from ..settings import CURRENCY_CHOICES, DECIMAL_PLACES, DEFAULT_CURRENCY, CURRENCY_CODE_MAX_LENGTH
+from ..settings import CURRENCY_CHOICES, CURRENCY_CODE_MAX_LENGTH, DECIMAL_PLACES, DEFAULT_CURRENCY
 from ..utils import MONEY_CLASSES, get_currency_field_name, prepare_expression
 
 

--- a/djmoney/settings.py
+++ b/djmoney/settings.py
@@ -35,4 +35,4 @@ BASE_CURRENCY = getattr(settings, "BASE_CURRENCY", "USD")
 EXCHANGE_BACKEND = getattr(settings, "EXCHANGE_BACKEND", "djmoney.contrib.exchange.backends.OpenExchangeRatesBackend")
 RATES_CACHE_TIMEOUT = getattr(settings, "RATES_CACHE_TIMEOUT", 600)
 
-CURRENCY_TICKER_MAX_LENGTH = 3
+CURRENCY_TICKER_MAX_LENGTH = getattr(settings, "CURRENCY_TICKER_MAX_LENGTH", 3)

--- a/djmoney/settings.py
+++ b/djmoney/settings.py
@@ -35,4 +35,4 @@ BASE_CURRENCY = getattr(settings, "BASE_CURRENCY", "USD")
 EXCHANGE_BACKEND = getattr(settings, "EXCHANGE_BACKEND", "djmoney.contrib.exchange.backends.OpenExchangeRatesBackend")
 RATES_CACHE_TIMEOUT = getattr(settings, "RATES_CACHE_TIMEOUT", 600)
 
-MAX_TICKER_LENGTH = 3
+CURRENCY_TICKER_MAX_LENGTH = 3

--- a/djmoney/settings.py
+++ b/djmoney/settings.py
@@ -35,4 +35,4 @@ BASE_CURRENCY = getattr(settings, "BASE_CURRENCY", "USD")
 EXCHANGE_BACKEND = getattr(settings, "EXCHANGE_BACKEND", "djmoney.contrib.exchange.backends.OpenExchangeRatesBackend")
 RATES_CACHE_TIMEOUT = getattr(settings, "RATES_CACHE_TIMEOUT", 600)
 
-CURRENCY_TICKER_MAX_LENGTH = getattr(settings, "CURRENCY_TICKER_MAX_LENGTH", 3)
+CURRENCY_CODE_MAX_LENGTH = getattr(settings, "CURRENCY_CODE_MAX_LENGTH", 3)

--- a/djmoney/settings.py
+++ b/djmoney/settings.py
@@ -34,3 +34,5 @@ FIXER_ACCESS_KEY = getattr(settings, "FIXER_ACCESS_KEY", None)
 BASE_CURRENCY = getattr(settings, "BASE_CURRENCY", "USD")
 EXCHANGE_BACKEND = getattr(settings, "EXCHANGE_BACKEND", "djmoney.contrib.exchange.backends.OpenExchangeRatesBackend")
 RATES_CACHE_TIMEOUT = getattr(settings, "RATES_CACHE_TIMEOUT", 600)
+
+MAX_TICKER_LENGTH = 3

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,9 @@ Changelog
 
 `Unreleased`_ - TBD
 -------------------
+**Added**
+
+- New setting ``CURRENCY_CODE_MAX_LENGTH`` configures default max_length for MoneyField and ``exchage`` app models. `#614`_ (`ayushin`_)
 
 `1.3.1`_ - 2021-02-04
 ---------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,7 +5,7 @@ Changelog
 -------------------
 **Added**
 
-- New setting ``CURRENCY_CODE_MAX_LENGTH`` configures default max_length for MoneyField and ``exchage`` app models. `#614`_ (`ayushin`_)
+- New setting ``CURRENCY_CODE_MAX_LENGTH`` configures default max_length for MoneyField and ``exchage`` app models.
 
 `1.3.1`_ - 2021-02-04
 ---------------------


### PR DESCRIPTION
Attention - this affects initial migration, so CURRENCY_TICKER_MAX_LENGTH (default 3) can't be changed afterwards without creating a new migration