### PR TITLE
fix: Use `CURRENCY_CODE_MAX_LENGTH` in `MoneyField`

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -170,7 +170,7 @@ class MoneyField(models.DecimalField):
         default=NOT_PROVIDED,
         default_currency=DEFAULT_CURRENCY,
         currency_choices=CURRENCY_CHOICES,
-        currency_max_length=3,
+        currency_max_length=CURRENCY_CODE_MAX_LENGTH,
         currency_field_name=None,
         money_descriptor_class=MoneyFieldProxy,
         **kwargs

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,9 +3,10 @@ Changelog
 
 `Unreleased`_ - TBD
 -------------------
+
 **Added**
 
-- New setting ``CURRENCY_CODE_MAX_LENGTH`` configures default max_length for MoneyField and ``exchage`` app models.
+- New setting ``CURRENCY_CODE_MAX_LENGTH`` configures default max_length for MoneyField and ``exchange`` app models.
 
 `1.3.1`_ - 2021-02-04
 ---------------------


### PR DESCRIPTION
Fixes #617