### PR TITLE
Copying attributes from non Money classes incorrectly assumes 0

### DIFF
--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -67,9 +67,9 @@ class Money(DefaultMoney):
         """
         for attribute_name in ("decimal_places", "_decimal_places_display"):
             selection = [
-                getattr(candidate, attribute_name, 0)
+                getattr(candidate, attribute_name, None)
                 for candidate in (self, source)
-                if getattr(candidate, attribute_name, 0) is not None
+                if getattr(candidate, attribute_name, None) is not None
             ]
             if selection:
                 value = max(selection)

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -187,13 +187,25 @@ def test_proper_copy_of_attributes(decimal_places_display, decimal_places):
     assert two._decimal_places_display is None, "default value"
     assert two.decimal_places == decimal_places
 
-    three = Money(3, "EUR")
-    one._copy_attributes(two, three)
+    result = Money(3, "EUR")
+    one._copy_attributes(two, result)
 
-    assert three._decimal_places_display == decimal_places_display
-    assert three.decimal_places == max(2, decimal_places) if decimal_places is not None else 2
+    assert result._decimal_places_display == decimal_places_display
+    assert result.decimal_places == max(2, decimal_places) if decimal_places is not None else 2
 
-    zero = Money(0, "EUR")
-    one._copy_attributes(Money(1, "EUR", decimal_places_display=3), zero)
+    result = Money(0, "EUR")
+    one._copy_attributes(Money(1, "EUR", decimal_places_display=3), result)
 
-    assert zero._decimal_places_display == max(3, decimal_places_display) if decimal_places_display is not None else 3
+    assert result._decimal_places_display == max(3, decimal_places_display) if decimal_places_display is not None else 3
+
+    result = Money(0, "EUR")
+    one._copy_attributes(1, result)
+
+    assert result._decimal_places_display == decimal_places_display
+    assert result.decimal_places == 2
+
+    result = Money(0, "EUR")
+    two._copy_attributes(1, result)
+
+    assert result._decimal_places_display is None
+    assert result.decimal_places == decimal_places if decimal_places else 2


### PR DESCRIPTION
copying attributes with a non Money object, incorrectly set attributes to 0 (Version 2.0.2)


Quick proof of case 
```
> from djmoney.money import Money
> effe = Money("1.23", "EUR")
> print(effe)

€1.23

> print(effe._decimal_places_display)

None

> effe = effe * 1
> print(effe)

1 €   <- expected €1.23

> print(effe._decimal_places_display)

0  <- expected None

```

I extended my previous test case