### PR TITLE
Update changelog before 2.1 release

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,12 +1,22 @@
 Changelog
 =========
 
+`Unreleased`_ - TBA
+-------------------
+
+- Add changes here
+
 `2.1`_ - 2021-09-17
 -------------------
 
-- Drop support for Django 1.11, 2.1 and 3.0.
-- Drop support for Python 3.5.
-- Add support for Django 3.2.
+**Added**
+
+- Add support for Django 3.2. `#612`_ (`antonagestam`_)
+
+**Removed**
+
+- Drop support for Django 1.11, 2.1 and 3.0. `#612`_ (`antonagestam`_)
+- Drop support for Python 3.5. `#612`_ (`antonagestam`_)
 
 `2.0.3`_ - 2021-09-04
 ---------------------
@@ -757,6 +767,7 @@ wrapping with ``money_manager``.
 .. _#630: https://github.com/django-money/django-money/pull/630
 .. _#629: https://github.com/django-money/django-money/pull/629
 .. _#624: https://github.com/django-money/django-money/issues/624
+.. _#612: https://github.com/django-money/django-money/pull/612
 .. _#603: https://github.com/django-money/django-money/issues/603
 .. _#595: https://github.com/django-money/django-money/issues/595
 .. _#593: https://github.com/django-money/django-money/issues/593


### PR DESCRIPTION
Doing this properly now, committing directly to `main` was very uncool of me and didn't work anyways.