### PR TITLE
Rename env names from master=>main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,13 +58,13 @@ jobs:
           - python: 3.8
             tox_env: django31-py38
           - python: 3.8
-            tox_env: django_master-py38
+            tox_env: django_main-py38
           - python: 3.9
             tox_env: django22-py39
           - python: 3.9
             tox_env: django31-py39
           - python: 3.9
-            tox_env: django_master-py39
+            tox_env: django_main-py39
     name: ${{ matrix.tox_env }}
     runs-on: ubuntu-latest
     steps:

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ django-money
    :target: https://github.com/django-money/django-money/actions
    :alt: Build Status
 
-.. image:: http://codecov.io/github/django-money/django-money/coverage.svg?branch=master
-   :target: http://codecov.io/github/django-money/django-money?branch=master
+.. image:: http://codecov.io/github/django-money/django-money/coverage.svg?branch=main
+   :target: http://codecov.io/github/django-money/django-money?branch=main
    :alt: Coverage Status
 
 .. image:: https://readthedocs.org/projects/django-money/badge/?version=latest

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 `Unreleased`_ - TBA
 -------------------
 
-- Add changes here
+- Renamed ``master`` branch to ``main`` (`benjaoming`_)
 
 `2.1`_ - 2021-09-17
 -------------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    django_master-py{39,38,37,36,py3}
+    django_main-py{39,38,37,36,py3}
     django32-py{39,38,37,36,py3}
     django31-py{39,38,37,36,py3}
     django22-py{39,38,37,36,py3}
@@ -18,11 +18,11 @@ deps =
     django22: {[django]2.2.x}
     django31: {[django]3.1.x}
     django32: {[django]3.2.x}
-    django_master: {[django]master}
+    django_main: {[django]main}
 commands = py.test --ds=tests.settings_reversion --cov=./djmoney {posargs}
 usedevelop = false
 
-[testenv:django_master-py{39,38,py3}]
+[testenv:django_main-py{39,38,py3}]
 commands = py.test --ds=tests.settings --cov=./djmoney {posargs}
 
 [testenv:lint]
@@ -44,7 +44,7 @@ commands =
         Django>=3.2,<3.3
         django-reversion>=3.0.8
         djangorestframework>=3.12.0
-master =
+main =
        https://github.com/django/django/tarball/main
        djangorestframework>=3.12.0
 


### PR DESCRIPTION
~Unrelated to 2.1 release, should be able to go in afterwards~

Seems to be fine, adding for 2.1