### PR TITLE
Include default_currency in deconstruct when not matching __init__ value

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -298,8 +298,11 @@ class MoneyField(models.DecimalField):
 
         if self._has_default:
             kwargs["default"] = self.default.amount
-        if self.default_currency is not None and self.default_currency != DEFAULT_CURRENCY:
-            kwargs["default_currency"] = str(self.default_currency)
+        if self.default_currency != DEFAULT_CURRENCY:
+            if self.default_currency is not None:
+                kwargs["default_currency"] = str(self.default_currency)
+            else:
+                kwargs["default_currency"] = None
         if self.currency_choices != CURRENCY_CHOICES:
             kwargs["currency_choices"] = self.currency_choices
         if self.currency_field_name:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -787,3 +787,11 @@ def test_mixer_blend():
         instance = mixer.blend(ModelWithTwoMoneyFields)
         assert isinstance(instance.amount1, Money)
         assert isinstance(instance.amount2, Money)
+
+
+def test_deconstruct_includes_default_currency_as_none():
+    instance = ModelWithNullableCurrency()._meta.get_field("money")
+    __, ___, args, kwargs = instance.deconstruct()
+    new = MoneyField(*args, **kwargs)
+    assert new.default_currency == instance.default_currency
+    assert new.default_currency is None


### PR DESCRIPTION
Fixes #646 

---

Since `MoneyField.__init__` specifies `default_currency=DEFAULT_CURRENCY`, we should include `default_currency` in deconstruct-kwargs appropriately as soon as `self.default_currency != DEFAULT_CURRENCY`.

I think the changes here aligns with the documentation:

> If you haven’t added any extra options on top of the field you inherited from, then there’s no need to write a new deconstruct() method. __If, however, you’re changing the arguments passed in \_\_init\_\_() (like we are in HandField), you’ll need to supplement the values being passed__.

More on Django's field deconstruction can be found here: https://docs.djangoproject.com/en/dev/howto/custom-model-fields/#field-deconstruction