### PR TITLE
Include currency_max_length in MoneyField.deconstruct

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -307,6 +307,8 @@ class MoneyField(models.DecimalField):
             kwargs["currency_choices"] = self.currency_choices
         if self.currency_field_name:
             kwargs["currency_field_name"] = self.currency_field_name
+        if self.currency_max_length != CURRENCY_CODE_MAX_LENGTH:
+            kwargs["currency_max_length"] = self.currency_max_length
         return name, path, args, kwargs
 
 


### PR DESCRIPTION
I found a similar issue regarding `MoneyField.deconstruct` and Django detecting changes via `python manage.py makemigrations` as mentioned in: https://github.com/django-money/django-money/issues/530#issuecomment-650166087 and #646 

Though this time for the option `currency_max_length`.

I also took the liberty to expand with an additional test for deconstruction of `default_currency`.