### PR TITLE
Fix Django 3.2 warning about default_app_config

### DIFF
--- a/djmoney/__init__.py
+++ b/djmoney/__init__.py
@@ -1,2 +1,10 @@
 __version__ = "2.1.1"
-default_app_config = "djmoney.apps.MoneyConfig"
+
+try:
+    import django
+
+    if django.VERSION < (3, 2):
+        default_app_config = "djmoney.apps.MoneyConfig"
+except ModuleNotFoundError:
+    # this part is useful for allow setup.py to be used for version checks
+    pass


### PR DESCRIPTION
Fix the following warning:
```
django.utils.deprecation.RemovedInDjango41Warning: 'djmoney' defines
default_app_config = 'djmoney.apps.MoneyConfig'. Django now detects
this configuration automatically. You can remove default_app_config.
```

https://docs.djangoproject.com/en/4.0/releases/3.2/#automatic-appconfig-discovery
Copied from how django-extensions handles this:
https://github.com/django-extensions/django-extensions/blob/main/django_extensions/__init__.py