### PR TITLE
Better default setup on `MoneyField` for models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,6 @@ docs/_build
 
 # Coverage reports
 .coverage
+.coverage.*
 coverage.xml
 htmlcov

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Changelog
 
 - Improve the internal check for whether a currency is provided `#657`_ (`davidszotten`_)
 - Fix test suite for django main branch `#657`_ (`davidszotten`_)
+- ``MoneyField`` raises ``TypeError`` when default contains a valid amount but no currence, i.e. ``Money(123, None)``. `#661`_ (`flaeppe`_)
+- ``MoneyField`` supports default of type ``bytes`` `#661`_ (`flaeppe`_)
 
 **Added**
 
@@ -792,6 +794,7 @@ wrapping with ``money_manager``.
 .. _0.3: https://github.com/django-money/django-money/compare/0.2...0.3
 .. _0.2: https://github.com/django-money/django-money/compare/0.2...a6d90348085332a393abb40b86b5dd9505489b04
 
+.. _#661: https://github.com/django-money/django-money/issues/657
 .. _#657: https://github.com/django-money/django-money/issues/657
 .. _#648: https://github.com/django-money/django-money/issues/648
 .. _#646: https://github.com/django-money/django-money/issues/646

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -215,3 +215,7 @@ class PreciseModel(models.Model):
 
 class ModelWithDefaultPrecision(models.Model):
     money = MoneyField(max_digits=10)
+
+
+class ModelWithNullDefaultOnNonNullableField(models.Model):
+    money = MoneyField(max_digits=10, decimal_places=2, default=None, default_currency=None)


### PR DESCRIPTION
Hi, I was digging in to making some progress on #638 (refs: #621) and realised that there was some adjustments that could be made for defaults on `djmoney.models.fields.MoneyField`. I've gathered several (minor) fixes in this PR(see list below), all of them originating from the same method.

- Removes possibility of allowing _any_ currency code on string based default value
- Having a default as type `bytes` is now properly supported
- Asserts on incompatible defaults with default currency being `None` when amount has a valid type (i.e. a default setup generating `Money(10, None)`)

_I think_ the changes here pushes work for #638 at least a little bit forward, as one of the major changes there would (probably?) be setting `DEFAULT_CURRENCY=None` per default. While the changes here help out on management of `MoneyField(..., default_currency=None)`. And I was thinking it could be nice taking the opportunity helping reduce the size of the work on #638.

Anyways, let me know what you think.