### PR TITLE
Fix django app config default

### DIFF
--- a/djmoney/__init__.py
+++ b/djmoney/__init__.py
@@ -1,2 +1,10 @@
+import django
+
 __version__ = "2.1.1"
-default_app_config = "djmoney.apps.MoneyConfig"
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = "djmoney.apps.MoneyConfig"
+


### PR DESCRIPTION
What does this PR do ?
- It solves the fix warnings `default_app_config`.


Full error details :

`RemovedInDjango41Warning: 'djmoney' defines default_app_config = 'djmoney.apps.MoneyConfig'. Django now detects this configuration automatically. You can remove default_app_config.`