### PR TITLE
Make pre-commit config work for others than Pyhon 3.9, fix Django 5.0 warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.9
+  python: python3
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0

--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -114,7 +114,13 @@ class Money(DefaultMoney):
     @property
     def is_localized(self):
         if self.use_l10n is None:
-            return settings.USE_L10N
+            # This definitely raises a warning in Django 4 - we want to ignore RemovedInDjango50Warning
+            # However, we cannot ignore this specific warning class as it doesn't exist in older
+            # Django versions
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore")
+                setting = getattr(settings, "USE_L10N", True)
+            return setting
         return self.use_l10n
 
     def __str__(self):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,8 @@
 import warnings
 from decimal import ROUND_HALF_EVEN
 
+import django
+
 import moneyed
 from moneyed.localization import _FORMATTER, DEFAULT
 
@@ -33,7 +35,10 @@ SITE_ID = 1
 
 SECRET_KEY = "foobar"
 
-USE_L10N = True
+
+# This now defaults to True and raises RemovedInDjango50Warning
+if django.VERSION < (4, 0):
+    USE_L10N = True
 
 
 _FORMATTER.add_sign_definition("pl_PL", moneyed.PLN, suffix=" zł")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,3 +1,4 @@
+import django
 import django.contrib.admin.utils as admin_utils
 
 import pytest
@@ -22,7 +23,9 @@ INTEGER_FIELD = ModelWithVanillaMoneyField._meta.get_field("integer")
     ),
 )
 def test_display_for_field_with_legacy_formatting(legacy_formatting, settings, value, expected):
-    settings.USE_L10N = True
+    # This now defaults to True and raises RemovedInDjango50Warning
+    if django.VERSION < (4, 0):
+        settings.USE_L10N = True
     # This locale has no definitions in py-moneyed, so it will work for localized money representation.
     settings.LANGUAGE_CODE = "cs"
     settings.DECIMAL_PLACES_DISPLAY = {}
@@ -40,7 +43,9 @@ def test_display_for_field_with_legacy_formatting(legacy_formatting, settings, v
     ),
 )
 def test_display_for_field(settings, value, expected):
-    settings.USE_L10N = True
+    # This now defaults to True and raises RemovedInDjango50Warning
+    if django.VERSION < (4, 0):
+        settings.USE_L10N = True
     # This locale has no definitions in py-moneyed, so it will work for localized money representation.
     settings.LANGUAGE_CODE = "cs"
     assert admin_utils.display_for_field(value, MONEY_FIELD, "") == expected

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,3 +1,4 @@
+import django
 from django.template import Context, Template, TemplateSyntaxError
 from django.utils.translation import override
 
@@ -150,8 +151,12 @@ def test_tag(string, result, context):
     ),
 )
 def test_l10n_off(settings, string, result, context):
-    settings.USE_L10N = False
-    assert_template(string, result, context)
+    # This test is only nice to run in older version of Django that do not either
+    # complain that the setting is deprecated or as of Django 5.0 entirely ignores
+    # this setting
+    if django.VERSION < (4, 0):
+        settings.USE_L10N = False
+        assert_template(string, result, context)
 
 
 def test_forced_l10n():


### PR DESCRIPTION
New upstream django `main` branch is giving test failures