### PR TITLE
Remove leftovers of deprecated `Money.decimal_places_display`

### DIFF
--- a/djmoney/money.py
+++ b/djmoney/money.py
@@ -41,15 +41,13 @@ class Money(DefaultMoney):
 
         When it comes to what number of decimal places to choose, we take the maximum number.
         """
-        for attribute_name in ("decimal_places", "_decimal_places_display"):
-            selection = [
-                getattr(candidate, attribute_name, None)
-                for candidate in (self, source)
-                if getattr(candidate, attribute_name, None) is not None
-            ]
-            if selection:
-                value = max(selection)
-                setattr(target, attribute_name, value)
+        selection = [
+            getattr(candidate, "decimal_places", None)
+            for candidate in (self, source)
+            if getattr(candidate, "decimal_places", None) is not None
+        ]
+        if selection:
+            target.decimal_places = max(selection)
 
     def __add__(self, other):
         if isinstance(other, F):

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -120,28 +120,8 @@ def test_sub_negative():
     assert total == Money(-33, "EUR")
 
 
-@pytest.mark.parametrize(
-    "decimal_places_display, decimal_places",
-    [
-        [None, None],
-        [0, 0],
-        [1, 0],
-        [4, 0],
-        [0, 1],
-        [1, 1],
-        [4, 1],
-        [0, 4],
-        [1, 4],
-        [4, 4],
-        [None, 4],
-        [None, 1],
-        [None, 0],
-        [4, None],
-        [1, None],
-        [0, None],
-    ],
-)
-def test_proper_copy_of_attributes(decimal_places_display, decimal_places):
+@pytest.mark.parametrize("decimal_places", [None, 0, 1, 4])
+def test_proper_copy_of_attributes(decimal_places):
     one = Money(1, "EUR")
 
     assert one.decimal_places == 2, "default value"


### PR DESCRIPTION
I found some leftovers to remove of `decimal_places_display` deprecation done in #638