### PR TITLE
rate is always 1 if source and target are equal

### DIFF
--- a/djmoney/contrib/exchange/models.py
+++ b/djmoney/contrib/exchange/models.py
@@ -40,6 +40,8 @@ def get_rate(source, target, backend=None):
     Converts exchange rate on the DB side if there is no backends with given base currency.
     Uses data from the default backend if the backend is not specified.
     """
+    if str(source) == str(target):
+        return 1
     if backend is None:
         backend = get_default_backend_name()
     key = f"djmoney:get_rate:{source}:{target}:{backend}"
@@ -53,8 +55,6 @@ def get_rate(source, target, backend=None):
 
 def _get_rate(source, target, backend):
     source, target = str(source), str(target)
-    if str(source) == target:
-        return 1
     rates = Rate.objects.filter(currency__in=(source, target), backend=backend).select_related("backend")
     if not rates:
         raise MissingRate(f"Rate {source} -> {target} does not exist")

--- a/tests/contrib/exchange/test_model.py
+++ b/tests/contrib/exchange/test_model.py
@@ -64,8 +64,10 @@ def test_string_representation(backend):
 def test_cache():
     with patch("djmoney.contrib.exchange.models._get_rate", wraps=_get_rate) as original:
         assert get_rate("USD", "USD") == 1
+        assert original.call_count == 0
+        assert get_rate("USD", "EUR") == 2
         assert original.call_count == 1
-        assert get_rate("USD", "USD") == 1
+        assert get_rate("USD", "EUR") == 2
         assert original.call_count == 1
 
 

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -106,7 +106,7 @@ class TestMoneyField:
 
     def test_serializer_with_fields(self):
         serializer = self.get_serializer(ModelWithVanillaMoneyField, data={"money": "10.00"}, fields_=("money",))
-        serializer.is_valid(True)
+        serializer.is_valid(raise_exception=True)
         assert serializer.data == {"money": "10.00"}
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
we don't even need to cache that ;)

Fixes #688 