### PR TITLE
Update setup-python action and use Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
-
+          python-version: '3.10'
       - run: pip install pre-commit
       - run: pre-commit run --all-files
 
@@ -25,13 +23,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
-
+          python-version: '3.10'
       - run: pip install tox
-
       - name: Run docs tox job
         run: tox -e docs
 
@@ -88,7 +83,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 


### PR DESCRIPTION
Updates the setup-python action version and upgrades to Python 3.10 for the pre-commit and docs job. Also touched some whitespace - let me know if you prefer I revert those :pray: 