### PR TITLE
Fix invalid flake8 repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,8 +52,6 @@ jobs:
             tox_env: django40-py38
           - python: '3.8'
             tox_env: django41-py38
-          - python: '3.8'
-            tox_env: django_main-py38
           - python: '3.9'
             tox_env: django22-py39
           - python: '3.9'
@@ -62,8 +60,6 @@ jobs:
             tox_env: django40-py39
           - python: '3.9'
             tox_env: django41-py39
-          - python: '3.9'
-            tox_env: django_main-py39
           - python: '3.10'
             tox_env: django22-py310
           - python: '3.10'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       -   id: isort
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    django_main-py{310,39,38,py3}
+    django_main-py{310}
     django41-py{310,39,38,py3}
     django40-py{310,39,38,py3}
     django32-py{310,39,38,37,py3}

--- a/tox.ini
+++ b/tox.ini
@@ -16,10 +16,10 @@ python_paths = {toxinidir}
 [testenv]
 deps =
     .[test,exchange]
-    django22: {[django]2.2.x}
-    django32: {[django]3.2.x}
-    django40: {[django]4.0.x}
-    django41: {[django]4.1.x}
+    django22: {[django]22}
+    django32: {[django]32}
+    django40: {[django]40}
+    django41: {[django]41}
     django_main: {[django]main}
 commands = py.test --ds=tests.settings_reversion --cov=./djmoney {posargs}
 usedevelop = false
@@ -34,19 +34,19 @@ commands =
     pre-commit run --all-files
 
 [django]
-2.2.x  =
+22  =
        Django>=2.2,<2.3
        django-reversion>=2.0.8
        djangorestframework>=3.7.3
-3.2.x  =
+32  =
         Django>=3.2,<3.3
         django-reversion>=3.0.8
         djangorestframework>=3.12.0
-4.0.x  =
+40  =
        Django>=4.0,<4.1
        django-reversion>=4.0.0
        djangorestframework>=3.13.0
-4.1.x  =
+41 =
        Django>=4.1a1,<4.2
        django-reversion>=4.0.0
        djangorestframework>=3.13.0


### PR DESCRIPTION
Switch from Gitlab to GitHub flake8 repository in pre-commit-config.yaml .

Closes #696 