### PR TITLE
Add support for Python 3.11 and Django 4.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,10 +40,6 @@ jobs:
             tox_env: django32-pypy3
           - python: pypy-3.8
             tox_env: django40-pypy3
-          - python: pypy-3.8
-            tox_env: django41-pypy3
-          - python: pypy-3.8
-            tox_env: django42-pypy3
           - python: '3.7'
             tox_env: django22-py37
           - python: '3.7'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,10 @@ jobs:
             tox_env: django32-pypy3
           - python: pypy-3.8
             tox_env: django40-pypy3
+          - python: pypy-3.8
+            tox_env: django41-pypy3
+          - python: pypy-3.8
+            tox_env: django42-pypy3
           - python: '3.7'
             tox_env: django22-py37
           - python: '3.7'
@@ -52,6 +56,8 @@ jobs:
             tox_env: django40-py38
           - python: '3.8'
             tox_env: django41-py38
+          - python: '3.8'
+            tox_env: django42-py38
           - python: '3.9'
             tox_env: django22-py39
           - python: '3.9'
@@ -60,6 +66,8 @@ jobs:
             tox_env: django40-py39
           - python: '3.9'
             tox_env: django41-py39
+          - python: '3.9'
+            tox_env: django42-py39
           - python: '3.10'
             tox_env: django22-py310
           - python: '3.10'
@@ -69,8 +77,24 @@ jobs:
           - python: '3.10'
             tox_env: django41-py310
           - python: '3.10'
+            tox_env: django42-py310
+          - python: '3.10'
             tox_env: django_main-py310
           - python: '3.10'
+            tox_env: no_rest_framework
+          - python: '3.11'
+            tox_env: django_main-py311
+          - python: '3.11'
+            tox_env: django42-py311
+          - python: '3.11'
+            tox_env: django41-py311
+          - python: '3.11'
+            tox_env: django40-py311
+          - python: '3.11'
+            tox_env: django32-py311
+          - python: '3.11'
+            tox_env: django22-py311
+          - python: '3.11'
             tox_env: no_rest_framework
     name: ${{ matrix.tox_env }}
     runs-on: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ fields in your models and forms.
 
 * Django versions supported: 2.2, 3.2, 4.0, 4.1, 4.2
 * Python versions supported: 3.7, 3.8, 3.9, 3.10, 3.11
-* PyPy versions supported: PyPy3
+* PyPy versions supported: PyPy3 (for Django <= 4.0)
 
 If you need support for older versions of Django and Python, please refer to older releases mentioned in `the release notes <https://django-money.readthedocs.io/en/latest/changes.html>`__.
 

--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,8 @@ django-money
 A little Django app that uses `py-moneyed <https://github.com/py-moneyed/py-moneyed>`__ to add support for Money
 fields in your models and forms.
 
-* Django versions supported: 2.2, 3.2, 4.0, 4.1
-* Python versions supported: 3.7, 3.8, 3.9, 3.10
+* Django versions supported: 2.2, 3.2, 4.0, 4.1, 4.2
+* Python versions supported: 3.7, 3.8, 3.9, 3.10, 3.11
 * PyPy versions supported: PyPy3
 
 If you need support for older versions of Django and Python, please refer to older releases mentioned in `the release notes <https://django-money.readthedocs.io/en/latest/changes.html>`__.

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 envlist =
-    django_main-py{310}
-    django41-py{310,39,38,py3}
-    django40-py{310,39,38,py3}
-    django32-py{310,39,38,37,py3}
-    django22-py{310,39,38,37,py3}
+    django_main-py{311,310}
+    django42-py{311,310,39,38,py3}
+    django41-py{311,310,39,38,py3}
+    django40-py{311,310,39,38,py3}
+    django32-py{311,310,39,38,37,py3}
+    django22-py{311,310,39,38,37,py3}
     lint
     docs
 skipsdist = true
@@ -20,6 +21,7 @@ deps =
     django32: {[django]32}
     django40: {[django]40}
     django41: {[django]41}
+    django42: {[django]42}
     django_main: {[django]main}
 commands = py.test --ds=tests.settings_reversion --cov=./djmoney {posargs}
 usedevelop = false
@@ -48,6 +50,10 @@ commands =
        djangorestframework>=3.13.0
 41 =
        Django>=4.1a1,<4.2
+       django-reversion>=4.0.0
+       djangorestframework>=3.13.0
+42 =
+       Django>=4.2a1,<4.3
        django-reversion>=4.0.0
        djangorestframework>=3.13.0
 main =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     django_main-py{311,310}
-    django42-py{311,310,39,38,py3}
+    django42-py{311,310,39,38}
     django41-py{311,310,39,38,py3}
     django40-py{311,310,39,38,py3}
     django32-py{311,310,39,38,37,py3}


### PR DESCRIPTION
Python 3.11 - everything is OK.
Django 4.2 - it's a beta version. Working properly, excluding pypy3

I discovered that Django 4.1 and 4.2 doesn't work properly under pypy3. I mentioned this fact in the README. The error:

```
File "/home/runner/work/django-money/django-money/.tox/django42-pypy3/lib/pypy3.8/site-packages/django/contrib/admin/decorators.py", line 102, in _model_admin_wrapper

raise ValueError("site must subclass AdminSite")

ValueError: site must subclass AdminSite
```

Closes #699 