### PR TITLE
Fix: add support for both `data.fixer.io` and `api.apilayer.com` auth params

### DIFF
--- a/djmoney/contrib/exchange/backends/fixer.py
+++ b/djmoney/contrib/exchange/backends/fixer.py
@@ -15,4 +15,8 @@ class FixerBackend(SimpleExchangeBackend):
         self.access_key = access_key
 
     def get_params(self):
-        return {"apikey": self.access_key}
+        # support both `data.fixer.io` and `api.apilayer.com` auth params
+        return {
+            "apikey": self.access_key,
+            "access_key": self.access_key,
+        }


### PR DESCRIPTION
In the current state of the project, exchange rates request from fixer.io does not work. This change allows you to work with both available API entry points: `data.fixer.io` and `api.apilayer.com`.

ApiLayer seems unreliable to me, getting a lot of timeouts and HTTP Error 524.