### PR TITLE
Tox: pypy3 downgrade asgiref

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,11 @@ usedevelop = false
 [testenv:django_main-py{39,38,py3}]
 commands = py.test --ds=tests.settings --cov=./djmoney {posargs}
 
+[testenv:py{py3}]
+deps =
+    # https://github.com/django-money/django-money/pull/716#issuecomment-1592594627
+    asgiref<=3.6
+
 [testenv:lint]
 deps =
     pre-commit


### PR DESCRIPTION
@alexnorgaard this change probably fail (I'm sure I did some mistake in the tox config), but you could see if you can have something like this to fix the issue in https://github.com/django-money/django-money/pull/716#issuecomment-1592594627