### PR TITLE
fixing issue with django rest framework when using MinMoneyValidator/MaxMoneyValidator

### DIFF
--- a/djmoney/contrib/django_rest_framework/fields.py
+++ b/djmoney/contrib/django_rest_framework/fields.py
@@ -65,8 +65,14 @@ class MoneyField(DecimalField):
         return super().to_internal_value(data)
 
     def get_value(self, data):
+        default_currency = None
+        if hasattr(self.parent, "Meta"):
+            model_meta = self.parent.Meta.model._meta
+            field = model_meta.get_field(self.field_name)
+            default_currency = field.default_currency
+
         amount = super().get_value(data)
-        currency = data.get(get_currency_field_name(self.field_name), self.default_currency)
+        currency = data.get(get_currency_field_name(self.field_name), self.default_currency or default_currency)
         if currency and amount is not None and not isinstance(amount, MONEY_CLASSES) and amount is not empty:
             return _PrimitiveMoney(amount=amount, currency=currency)
         return amount

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,7 +12,7 @@ Changelog
 **Fixed**
 
 - Revert 3.4 patch, meaning that auto-generated CurrencyField is once again part of migrations :github-issue:`731` (:github-user:`benjaoming`)
-
+- django-rest-framework: MinMoneyValidator and MaxMoneyValidator fixed, may require default_currency defined :github-issue:`722` (:github-user:`hosamhamdy258` :github-user:`errietta` :github-user:`benjaoming`)
 
 **Changed**
 
@@ -21,11 +21,11 @@ Changelog
 
 **Added**
 
-- Django 5.0 support
+- Django 5.0 support :github-issue:`753` (:github-user:`benjaoming`)
 
 **Removed**
 
-- Official support for Django 2.2, 3.2, 4.0, 4.1
+- Official support for Django 2.2, 3.2, 4.0, 4.1 :github-issue:`753` (:github-user:`benjaoming`)
 
 
 `3.4.1`_ - 2023-11-30

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -217,6 +217,8 @@ class TestMinValueSerializer:
         [
             pytest.param({"money": Money(-1, "EUR")}, False, id="is_invalid_money_value"),
             pytest.param({"money": Money(1, "EUR")}, True, id="is_valid_money_value"),
+            pytest.param({"money": "-1", "money_currency": "EUR"}, False, id="is_invalid_dict_value"),
+            pytest.param({"money": "0.01", "money_currency": "EUR"}, True, id="is_valid_dict_value"),
         ],
     )
     def test_serializer_validators(self, data, is_valid):

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -207,10 +207,10 @@ class TestMoneyField:
         assert serializer.validated_data["money"] == expected
 
 
+# Test case contributed for
+# https://github.com/django-money/django-money/pull/722
 class TestMinValueSerializer:
 
-    # Test case contributed for
-    # https://github.com/django-money/django-money/pull/722
     @override_settings(DEFAULT_CURRENCY="EUR")
     @pytest.mark.parametrize(
         ("data", "is_valid"),
@@ -221,7 +221,7 @@ class TestMinValueSerializer:
             pytest.param({"money": "0.01", "money_currency": "EUR"}, True, id="is_valid_dict_value"),
         ],
     )
-    def test_serializer_validators(self, data, is_valid):
+    def test_serializer_validator_field_without_default_currency(self, data, is_valid):
         from djmoney.contrib.django_rest_framework import MoneyField
 
         class MinValueSerializer(serializers.Serializer):
@@ -236,3 +236,28 @@ class TestMinValueSerializer:
         else:
             assert not serializer.is_valid()
             assert serializer.errors["money"][0] == "Ensure this value is greater than or equal to 0."
+
+    @pytest.mark.parametrize(
+        ("data", "is_valid"),
+        [
+            pytest.param({"second_money": Money(-1, "EUR")}, False, id="is_invalid_money_value"),
+            pytest.param({"second_money": Money(1, "EUR")}, True, id="is_valid_money_value"),
+            pytest.param({"second_money": "-1", "second_money_currency": "EUR"}, False, id="is_invalid_dict_value"),
+            pytest.param({"second_money": "0.01", "second_money_currency": "EUR"}, True, id="is_valid_dict_value"),
+        ],
+    )
+    def test_serializer_validator_field_with_default_currencey(self, data, is_valid):
+        from djmoney.contrib.django_rest_framework import MoneyField
+
+        class MinValueSerializer(serializers.Serializer):
+            second_money = MoneyField(decimal_places=2, max_digits=10, min_value=0)
+
+            class Meta:
+                model = ModelWithVanillaMoneyField
+
+        serializer = MinValueSerializer(data=data)
+        if is_valid:
+            assert serializer.is_valid()
+        else:
+            assert not serializer.is_valid()
+            assert serializer.errors["second_money"][0] == "Ensure this value is greater than or equal to 0."

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -224,3 +224,6 @@ class TestMinValueSerializer:
         serializer = MinValueSerializer(data={"money": "-1"})
         assert not serializer.is_valid()
         assert serializer.errors["money"][0] == "Ensure this value is greater than or equal to 0."
+
+        serializer = MinValueSerializer(data={"money": "1"})
+        assert serializer.is_valid()


### PR DESCRIPTION
issue : MinMoneyValidator or MaxMoneyValidator with ModelSerializer
error : Decimal object has no attribute amount
solution : getting default currency from source field on django model
expiation : default_currency is not passed to MoneyField Serializer