### PR TITLE
Map settings.BASE_CURRENCY to the base parameter for the openexchangerates.org backend

### DIFF
--- a/djmoney/contrib/exchange/backends/openexchangerates.py
+++ b/djmoney/contrib/exchange/backends/openexchangerates.py
@@ -18,4 +18,4 @@ class OpenExchangeRatesBackend(SimpleExchangeBackend):
         self.access_key = access_key
 
     def get_params(self):
-        return {"app_id": self.access_key}
+        return {"app_id": self.access_key, "base": settings.BASE_CURRENCY}


### PR DESCRIPTION
This PR fixes #751 by setting `base` to `settings.BASE_CURRENCY`. 

To solve this problem in a more thorough manner, `get_params` should accept kwargs and the `base_currency` variable should passed to it. But this would require breaking changes. 