### PR TITLE
Allow MoneyField to be used without a model serializer

### DIFF
--- a/djmoney/contrib/django_rest_framework/fields.py
+++ b/djmoney/contrib/django_rest_framework/fields.py
@@ -66,7 +66,9 @@ class MoneyField(DecimalField):
 
     def get_value(self, data):
         default_currency = None
-        if hasattr(self.parent, "Meta"):
+        parent_meta = getattr(self.parent, "Meta", None)
+
+        if parent_meta and hasattr(parent_meta, "model"):
             model_meta = self.parent.Meta.model._meta
             field = model_meta.get_field(self.field_name)
             default_currency = field.default_currency

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -261,3 +261,15 @@ class TestMinValueSerializer:
         else:
             assert not serializer.is_valid()
             assert serializer.errors["second_money"][0] == "Ensure this value is greater than or equal to 0."
+
+    def test_no_model_serializer(self):
+        from djmoney.contrib.django_rest_framework import MoneyField
+
+        class NormalSerializer(serializers.Serializer):
+            the_money = MoneyField(decimal_places=2, max_digits=10, min_value=0)
+
+            class Meta:
+                fields = ("the_money",)
+
+        serializer = NormalSerializer(data={"the_money": "0.01", "the_money_currency": "EUR"})
+        assert serializer.is_valid()


### PR DESCRIPTION
Fixes #757 from original regression caused by #722.

I added a test but I also manually validated in my environment and this fixes the stack trace I was getting!