### PR TITLE
Rename CELERYBEAT_SCHEDULE to CELERY_BEAT_SCHEDULE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -423,7 +423,7 @@ To set up a periodic rates update you could use Celery task:
 
 .. code:: python
 
-    CELERYBEAT_SCHEDULE = {
+    CELERY_BEAT_SCHEDULE = {
         'update_rates': {
             'task': 'path.to.your.task',
             'schedule': crontab(minute=0, hour=0),


### PR DESCRIPTION
Small adjustment to align the celery beat configuration with the new style naming convention. 

In the new convention the variable is called `beat_schedule` so it expects `CELERY_BEAT_SCHEDULE` when using celery with namespace='CELERY'. 