### PR TITLE
fixes #768 where MoneyField breaks when using referencing properties …

### DIFF
--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -9,10 +9,11 @@ from djmoney.money import Money
 
 from ..testapp.models import (
     ModelWithVanillaMoneyField,
+    MoneyFieldModelWithProperty,
     NullMoneyFieldModel,
     ValidatedMoneyModel,
-    MoneyFieldModelWithProperty,
 )
+
 
 pytestmark = pytest.mark.django_db
 serializers = pytest.importorskip("rest_framework.serializers")

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -129,6 +129,14 @@ class ModelManager(models.Manager):
     pass
 
 
+class MoneyFieldModelWithProperty(models.Model):
+    money = MoneyField(max_digits=10, decimal_places=2, default=0.0, default_currency="USD")
+
+    @property
+    def ten_extra_monies(self):
+        return self.money + Money(10, "USD")
+
+
 class NotNullMoneyFieldModel(models.Model):
     money = MoneyField(max_digits=10, decimal_places=2)
 


### PR DESCRIPTION
…on the model in drf serializer. 

Issue here: https://github.com/django-money/django-money/issues/768