### PR TITLE
Fix decompress for strings

### DIFF
--- a/djmoney/forms/widgets.py
+++ b/djmoney/forms/widgets.py
@@ -26,5 +26,8 @@ class MoneyWidget(MultiWidget):
         if value is not None:
             if isinstance(value, (list, tuple)):
                 return value
+            elif isinstance(value, str):
+                return (
+                    value.split(',') + [self.default_currency])[:2]
             return [value.amount, value.currency]
         return [None, self.default_currency]


### PR DESCRIPTION
If a string is passed, e.g. from a ModelAdmin /add/ query string, split it.  If no currency was provided, fall back to default_currency.

Without this, Django crashes.