### PR TITLE
Add getting a limit value from a callable

### DIFF
--- a/djmoney/models/validators.py
+++ b/djmoney/models/validators.py
@@ -9,14 +9,15 @@ from djmoney.money import Money
 
 class BaseMoneyValidator(BaseValidator):
     def get_limit_value(self, cleaned):
-        if isinstance(self.limit_value, Money):
-            if cleaned.currency.code != self.limit_value.currency.code:
+        limit_value = self.limit_value() if callable(self.limit_value) else self.limit_value
+        if isinstance(limit_value, Money):
+            if cleaned.currency.code != limit_value.currency.code:
                 return
-            return self.limit_value
-        elif isinstance(self.limit_value, (int, Decimal)):
-            return self.limit_value
+            return limit_value
+        elif isinstance(limit_value, (int, Decimal)):
+            return limit_value
         try:
-            return Money(self.limit_value[cleaned.currency.code], cleaned.currency.code)
+            return Money(limit_value[cleaned.currency.code], cleaned.currency.code)
         except KeyError:
             # There are no validation for this currency
             pass

--- a/tests/contrib/test_django_rest_framework.py
+++ b/tests/contrib/test_django_rest_framework.py
@@ -150,6 +150,8 @@ class TestMoneyField:
             (Money(600, "USD"), "Ensure this value is less than or equal to $500.00."),
             (Money(400, "NOK"), "Ensure this value is greater than or equal to NOK500.00."),
             (Money(950, "NOK"), "Ensure this value is less than or equal to NOK900.00."),
+            (Money(10, "DKK"), "Ensure this value is greater than or equal to DKK50.00."),
+            (Money(2500, "DKK"), "Ensure this value is less than or equal to DKK2,000.00."),
             (Money(5, "SEK"), "Ensure this value is greater than or equal to 10."),
             (Money(1600, "SEK"), "Ensure this value is less than or equal to 1500."),
         ),

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -40,6 +40,14 @@ def get_currency_choices():
     return [(code, code) for code in a_list]
 
 
+def get_min_value_validator():
+    return Money(50, "DKK")
+
+
+def get_max_value_validator():
+    return Money(2000, "DKK")
+
+
 class ModelWithVanillaMoneyField(models.Model):
     money = MoneyField(max_digits=10, decimal_places=2)
     second_money = MoneyField(max_digits=10, decimal_places=2, default=0.0, default_currency="EUR")
@@ -209,6 +217,8 @@ class ValidatedMoneyModel(models.Model):
             MaxMoneyValidator({"EUR": 1000, "USD": 500}),
             MinMoneyValidator(Money(500, "NOK")),
             MaxMoneyValidator(Money(900, "NOK")),
+            MinMoneyValidator(get_min_value_validator),
+            MaxMoneyValidator(get_max_value_validator),
             MinMoneyValidator(10),
             MaxMoneyValidator(1500),
         ],


### PR DESCRIPTION
Django's `BaseValidator` allow a callable for a `limit_value`. That is required for migrations. If we use a value from settings which can change, it leads to creating a new migration step.