### PR TITLE
docs: update README supported Python/Django versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,9 +20,9 @@ django-money
 A little Django app that uses `py-moneyed <https://github.com/py-moneyed/py-moneyed>`__ to add support for Money
 fields in your models and forms.
 
-* Django versions supported: 2.2, 3.2, 4.0, 4.1, 4.2
-* Python versions supported: 3.7, 3.8, 3.9, 3.10, 3.11
-* PyPy versions supported: PyPy3 (for Django <= 4.0)
+* Django versions supported: 4.2, 5.0, 5.1, 5.2
+* Python versions supported: 3.10, 3.11, 3.12, 3.13
+* PyPy versions supported: PyPy3
 
 If you need support for older versions of Django and Python, please refer to older releases mentioned in `the release notes <https://django-money.readthedocs.io/en/latest/changes.html>`__.
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,14 @@ Changelog
 =========
 
 
+Unreleased
+----------
+
+**Changed**
+
+- Update README to reflect currently supported Python (3.10–3.13) and Django (4.2–5.2) versions. :github-issue:`820` (:github-user:`smhtbtb`)
+
+
 `3.6`_ - 2026-01-27
 -------------------
 


### PR DESCRIPTION
Closes #820. Updates README.rst to match pyproject.toml classifiers (Python 3.10–3.13, Django 4.2–5.2). Adds a changelog entry per CONTRIBUTING.rst.