### PR TITLE
Allow MoneyField.hidden_widget to accept widget arguments

### DIFF
--- a/djmoney/forms/fields.py
+++ b/djmoney/forms/fields.py
@@ -61,11 +61,13 @@ class MoneyField(MultiValueField):
 
         self.initial = [default_amount, default_currency]
 
-    def hidden_widget(self):
+    def hidden_widget(self, *args, **kwargs):
         # TODO: This should inherit the constraints of the field
         #  Otherwise, we won't validate that min, max value and currency_choices are valid?
         # This is usually used to pre-fill the 'initial data' hidden input, so it's not very sensitive to tampering.
-        return HiddenMoneyWidget()
+        # Accept the same arguments as Django's default class-based hidden_widget so that
+        # callers such as django-crispy-forms can pass attrs through (#825).
+        return HiddenMoneyWidget(*args, **kwargs)
 
     def compress(self, data_list):
         if data_list:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,7 +5,9 @@ Changelog
 `Unreleased`_
 -------------
 
-...
+**Fixed**
+
+- ``MoneyField.hidden_widget`` now accepts arguments so callers such as django-crispy-forms can pass ``attrs`` :github-issue:`825` (:github-user:`SAY-5`)
 
 `3.6.1`_ - 2026-06-07
 ---------------------

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -188,6 +188,17 @@ def test_fields_default_amount_becomes_forms_initial():
     assert form.fields["money"].initial == [123, "PLN"]
 
 
+def test_hidden_widget_accepts_attrs():
+    """
+    hidden_widget should accept the arguments Django's default class-based
+    hidden_widget does, so third-party callers like django-crispy-forms can
+    pass attrs through. See #825.
+    """
+    field = MoneyField(max_digits=10, decimal_places=2).formfield()
+    widget = field.hidden_widget(attrs={"class": "foo"})
+    assert widget.attrs["class"] == "foo"
+
+
 def test_no_deprecation_warning():
     """
     The library's code shouldn't generate any warnings itself. See #262.


### PR DESCRIPTION
Closes #825. Django's default `hidden_widget` is a widget class, so callers like django-crispy-forms call `field.hidden_widget(attrs)`. MoneyField overrode it with a no-arg method, which raised TypeError. This forwards any args to HiddenMoneyWidget and adds a regression test plus a changelog entry.