### PR TITLE
fix: add type stubs for `MoneyField` to return `Money` instead of `Decimal`

### DIFF
--- a/djmoney/models/fields.pyi
+++ b/djmoney/models/fields.pyi
@@ -1,0 +1,34 @@
+from decimal import Decimal
+from typing import Any
+
+from django.db import models
+from django.db.models.expressions import Combinable
+
+from djmoney.money import Money
+
+class MoneyFieldProxy:
+    def __init__(self, field: MoneyField) -> None: ...
+    def __get__(self, obj: models.Model | None, type: Any = ...) -> Money | None: ...
+    def __set__(self, obj: models.Model, value: Any) -> None: ...
+
+class CurrencyField(models.CharField): ...
+
+class MoneyField(models.DecimalField):
+    _pyi_private_set_type: Money | Decimal | float | int | str | Combinable  # type: ignore[assignment]
+    _pyi_private_get_type: Money  # type: ignore[assignment]
+    _pyi_lookup_exact_type: Money | Decimal | int | str  # type: ignore[assignment]
+
+    def __init__(
+        self,
+        verbose_name: str | None = ...,
+        name: str | None = ...,
+        max_digits: int | None = ...,
+        decimal_places: int = ...,
+        default: Any = ...,
+        default_currency: Any = ...,
+        currency_choices: Any = ...,
+        currency_max_length: int = ...,
+        currency_field_name: str | None = ...,
+        money_descriptor_class: type[MoneyFieldProxy] = ...,
+        **kwargs: Any,
+    ) -> None: ...


### PR DESCRIPTION
## Summary

- Add `djmoney/models/fields.pyi` stub file with `_pyi_private_get_type: Money` so `django-stubs`' mypy plugin resolves `MoneyField` access as `Money` instead of `Decimal`
- Include `_pyi_private_set_type` and `_pyi_lookup_exact_type` for correct assignment and ORM lookup typing
- Add stub declarations for `MoneyFieldProxy` descriptor and `CurrencyField`

## Motivation

`MoneyField` extends `DecimalField`, so without explicit type stubs, `django-stubs` infers `Decimal` as the return type. At runtime, `MoneyFieldProxy` returns `Money` objects. This forces users to add `# type: ignore[return-value]` on every `MoneyField` access.

## How it works

`django-stubs`' mypy plugin reads `_pyi_private_set_type` and `_pyi_private_get_type` attributes from field class stubs to determine what types a field accepts and returns. By declaring these on `MoneyField` in a `.pyi` file, the existing plugin infrastructure handles everything — no custom mypy plugin needed. Nullable fields (`null=True`) are also handled automatically by the plugin.

## Test plan

- [x] Tested against a production Django project (390 source files) using `mypy` + `django-stubs`
- [x] All `MoneyField` accesses correctly resolve as `Money` instead of `Decimal`
- [x] Eliminated 70+ unnecessary `# type: ignore` comments
- [x] No regressions — 0 mypy errors after the change

Closes #829